### PR TITLE
Add parameter map

### DIFF
--- a/src/main/java/com/ldbc/driver/Operation.java
+++ b/src/main/java/com/ldbc/driver/Operation.java
@@ -2,6 +2,8 @@ package com.ldbc.driver;
 
 import com.ldbc.driver.temporal.TemporalUtil;
 
+import java.util.Map;
+
 public abstract class Operation<RESULT_TYPE>
 {
     private static final TemporalUtil temporalutil = new TemporalUtil();
@@ -50,6 +52,8 @@ public abstract class Operation<RESULT_TYPE>
                ", dependencyTimeStamp=" + temporalutil.milliTimeToDateTimeString( dependencyTimeStamp ) +
                '}';
     }
+
+    public abstract Map<String, Object> parameterMap();
 
     public abstract RESULT_TYPE marshalResult( String serializedOperationResult )
             throws SerializingMarshallingException;

--- a/src/main/java/com/ldbc/driver/runtime/executor/SingleThreadOperationExecutor.java
+++ b/src/main/java/com/ldbc/driver/runtime/executor/SingleThreadOperationExecutor.java
@@ -23,26 +23,27 @@ public class SingleThreadOperationExecutor implements OperationExecutor
     static final Operation TERMINATE_OPERATION = new Operation()
     {
         @Override
-        public Map<String, Object> parameterMap() {
-            return ImmutableMap.of();
+        public Map<String,Object> parameterMap()
+        {
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public int type()
         {
-            return -1;
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public Object marshalResult( String serializedOperationResult ) throws SerializingMarshallingException
         {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public String serializeResult( Object operationResultInstance ) throws SerializingMarshallingException
         {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
     };

--- a/src/main/java/com/ldbc/driver/runtime/executor/SingleThreadOperationExecutor.java
+++ b/src/main/java/com/ldbc/driver/runtime/executor/SingleThreadOperationExecutor.java
@@ -1,10 +1,7 @@
 package com.ldbc.driver.runtime.executor;
 
-import com.ldbc.driver.ChildOperationGenerator;
-import com.ldbc.driver.Db;
-import com.ldbc.driver.Operation;
-import com.ldbc.driver.SerializingMarshallingException;
-import com.ldbc.driver.WorkloadStreams;
+import com.google.common.collect.ImmutableMap;
+import com.ldbc.driver.*;
 import com.ldbc.driver.runtime.ConcurrentErrorReporter;
 import com.ldbc.driver.runtime.DefaultQueues;
 import com.ldbc.driver.runtime.QueueEventSubmitter;
@@ -14,6 +11,7 @@ import com.ldbc.driver.runtime.metrics.MetricsService;
 import com.ldbc.driver.runtime.scheduling.Spinner;
 import com.ldbc.driver.temporal.TimeSource;
 
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -24,6 +22,11 @@ public class SingleThreadOperationExecutor implements OperationExecutor
 {
     static final Operation TERMINATE_OPERATION = new Operation()
     {
+        @Override
+        public Map<String, Object> parameterMap() {
+            return ImmutableMap.of();
+        }
+
         @Override
         public int type()
         {

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery10TagPerson.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery10TagPerson.java
@@ -12,6 +12,10 @@ public class LdbcSnbBiQuery10TagPerson extends Operation<List<LdbcSnbBiQuery10Ta
 {
     public static final int TYPE = 10;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String TAG = "tag";
+    public static final String LIMIT = "limit";
+    public static final String DATE = "date";
+
     private final String tag;
     private final long date;
     private final int limit;
@@ -41,8 +45,9 @@ public class LdbcSnbBiQuery10TagPerson extends Operation<List<LdbcSnbBiQuery10Ta
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("tag", tag)
-                .put("limit", limit)
+                .put(TAG, tag)
+                .put(DATE, date)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery10TagPerson.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery10TagPerson.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery10TagPerson extends Operation<List<LdbcSnbBiQuery10TagPersonResult>>
 {
@@ -34,6 +36,14 @@ public class LdbcSnbBiQuery10TagPerson extends Operation<List<LdbcSnbBiQuery10Ta
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("tag", tag)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery11UnrelatedReplies.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery11UnrelatedReplies.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery11UnrelatedReplies extends Operation<List<LdbcSnbBiQuery11UnrelatedRepliesResult>>
 {
@@ -34,6 +36,15 @@ public class LdbcSnbBiQuery11UnrelatedReplies extends Operation<List<LdbcSnbBiQu
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("blackList", blackList)
+                .put("country", country)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery11UnrelatedReplies.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery11UnrelatedReplies.java
@@ -12,6 +12,10 @@ public class LdbcSnbBiQuery11UnrelatedReplies extends Operation<List<LdbcSnbBiQu
 {
     public static final int TYPE = 11;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String BLACK_LIST = "blackList";
+    public static final String COUNTRY = "country";
+    public static final String LIMIT = "limit";
+
     private final String country;
     private final List<String> blackList;
     private final int limit;
@@ -41,9 +45,9 @@ public class LdbcSnbBiQuery11UnrelatedReplies extends Operation<List<LdbcSnbBiQu
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("blackList", blackList)
-                .put("country", country)
-                .put("limit", limit)
+                .put(BLACK_LIST, blackList)
+                .put(COUNTRY, country)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery12TrendingPosts.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery12TrendingPosts.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery12TrendingPosts extends Operation<List<LdbcSnbBiQuery12TrendingPostsResult>>
 {
@@ -34,6 +36,15 @@ public class LdbcSnbBiQuery12TrendingPosts extends Operation<List<LdbcSnbBiQuery
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("date", date)
+                .put("likeCount", likeCount)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery12TrendingPosts.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery12TrendingPosts.java
@@ -12,6 +12,10 @@ public class LdbcSnbBiQuery12TrendingPosts extends Operation<List<LdbcSnbBiQuery
 {
     public static final int TYPE = 12;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String DATE = "date";
+    public static final String LIKE_THRESHOLD = "likeThreshold";
+    public static final String LIMIT = "limit";
+
     private final long date;
     private final int likeThreshold;
     private final int limit;
@@ -41,9 +45,9 @@ public class LdbcSnbBiQuery12TrendingPosts extends Operation<List<LdbcSnbBiQuery
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("date", date)
-                .put("likeCount", likeCount)
-                .put("limit", limit)
+                .put(DATE, date)
+                .put(LIKE_THRESHOLD, likeThreshold)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery13PopularMonthlyTags.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery13PopularMonthlyTags.java
@@ -13,6 +13,9 @@ public class LdbcSnbBiQuery13PopularMonthlyTags extends Operation<List<LdbcSnbBi
 {
     public static final int TYPE = 13;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String COUNTRY = "country";
+    public static final String LIMIT = "limit";
+
     private final String country;
     private final int limit;
 
@@ -35,8 +38,8 @@ public class LdbcSnbBiQuery13PopularMonthlyTags extends Operation<List<LdbcSnbBi
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("country", country)
-                .put("limit", limit)
+                .put(COUNTRY, country)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery13PopularMonthlyTags.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery13PopularMonthlyTags.java
@@ -1,11 +1,13 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery13PopularMonthlyTags extends Operation<List<LdbcSnbBiQuery13PopularMonthlyTagsResult>>
 {
@@ -28,6 +30,14 @@ public class LdbcSnbBiQuery13PopularMonthlyTags extends Operation<List<LdbcSnbBi
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("country", country)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery14TopThreadInitiators.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery14TopThreadInitiators.java
@@ -12,6 +12,10 @@ public class LdbcSnbBiQuery14TopThreadInitiators extends Operation<List<LdbcSnbB
 {
     public static final int TYPE = 14;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String BEGIN_DATE = "beginDate";
+    public static final String END_DATE = "endDate";
+    public static final String LIMIT = "limit";
+
     private final long beginDate;
     private final long endDate;
     private final int limit;
@@ -41,9 +45,9 @@ public class LdbcSnbBiQuery14TopThreadInitiators extends Operation<List<LdbcSnbB
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("beginDate", beginDate)
-                .put("endDate", endDate)
-                .put("limit", limit)
+                .put(BEGIN_DATE, beginDate)
+                .put(END_DATE, endDate)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery14TopThreadInitiators.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery14TopThreadInitiators.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery14TopThreadInitiators extends Operation<List<LdbcSnbBiQuery14TopThreadInitiatorsResult>>
 {
@@ -34,6 +36,15 @@ public class LdbcSnbBiQuery14TopThreadInitiators extends Operation<List<LdbcSnbB
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("beginDate", beginDate)
+                .put("endDate", endDate)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery15SocialNormals.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery15SocialNormals.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery15SocialNormals extends Operation<List<LdbcSnbBiQuery15SocialNormalsResult>>
 {
@@ -27,6 +29,14 @@ public class LdbcSnbBiQuery15SocialNormals extends Operation<List<LdbcSnbBiQuery
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("country", country)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery15SocialNormals.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery15SocialNormals.java
@@ -12,6 +12,9 @@ public class LdbcSnbBiQuery15SocialNormals extends Operation<List<LdbcSnbBiQuery
 {
     public static final int TYPE = 15;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String COUNTRY = "country";
+    public static final String LIMIT = "limit";
+
     private final String country;
     private final int limit;
 
@@ -34,8 +37,8 @@ public class LdbcSnbBiQuery15SocialNormals extends Operation<List<LdbcSnbBiQuery
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("country", country)
-                .put("limit", limit)
+                .put(COUNTRY, country)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery16ExpertsInSocialCircle.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery16ExpertsInSocialCircle.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery16ExpertsInSocialCircle extends Operation<List<LdbcSnbBiQuery16ExpertsInSocialCircleResult>>
 {
@@ -56,6 +58,18 @@ public class LdbcSnbBiQuery16ExpertsInSocialCircle extends Operation<List<LdbcSn
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("tagClass", tagClass)
+                .put("country", country)
+                .put("minPathDistance", minPathDistance)
+                .put("maxPathDistance", maxPathDistance)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery16ExpertsInSocialCircle.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery16ExpertsInSocialCircle.java
@@ -12,6 +12,13 @@ public class LdbcSnbBiQuery16ExpertsInSocialCircle extends Operation<List<LdbcSn
 {
     public static final int TYPE = 16;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String PERSON_ID = "personId";
+    public static final String TAG_CLASS = "tagClass";
+    public static final String COUNTRY = "country";
+    public static final String MIN_PATH_DISTANCE = "minPathDistance";
+    public static final String MAX_PATH_DISTANCE = "maxPathDistance";
+    public static final String LIMIT = "limit";
+
     private final long personId;
     private final String country;
     private final String tagClass;
@@ -63,12 +70,12 @@ public class LdbcSnbBiQuery16ExpertsInSocialCircle extends Operation<List<LdbcSn
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("tagClass", tagClass)
-                .put("country", country)
-                .put("minPathDistance", minPathDistance)
-                .put("maxPathDistance", maxPathDistance)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(TAG_CLASS, tagClass)
+                .put(COUNTRY, country)
+                .put(MIN_PATH_DISTANCE, minPathDistance)
+                .put(MAX_PATH_DISTANCE, maxPathDistance)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery17FriendshipTriangles.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery17FriendshipTriangles.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery17FriendshipTriangles extends Operation<LdbcSnbBiQuery17FriendshipTrianglesResult>
 {
@@ -19,6 +21,13 @@ public class LdbcSnbBiQuery17FriendshipTriangles extends Operation<LdbcSnbBiQuer
     public String country()
     {
         return country;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("country", country)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery17FriendshipTriangles.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery17FriendshipTriangles.java
@@ -11,6 +11,8 @@ import java.util.Map;
 public class LdbcSnbBiQuery17FriendshipTriangles extends Operation<LdbcSnbBiQuery17FriendshipTrianglesResult>
 {
     public static final int TYPE = 17;
+    public static final String COUNTRY = "country";
+
     private final String country;
 
     public LdbcSnbBiQuery17FriendshipTriangles( String country )
@@ -26,7 +28,7 @@ public class LdbcSnbBiQuery17FriendshipTriangles extends Operation<LdbcSnbBiQuer
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("country", country)
+                .put(COUNTRY, country)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery18PersonPostCounts.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery18PersonPostCounts.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery18PersonPostCounts extends Operation<List<LdbcSnbBiQuery18PersonPostCountsResult>>
 {
@@ -41,6 +43,16 @@ public class LdbcSnbBiQuery18PersonPostCounts extends Operation<List<LdbcSnbBiQu
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("date", date)
+                .put("lengthThreshold", lengthThreshold)
+                .put("languages", languages)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery18PersonPostCounts.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery18PersonPostCounts.java
@@ -12,6 +12,11 @@ public class LdbcSnbBiQuery18PersonPostCounts extends Operation<List<LdbcSnbBiQu
 {
     public static final int TYPE = 18;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String DATE = "date";
+    public static final String LENGTH_THRESHOLD = "lengthThreshold";
+    public static final String LANGUAGES = "languages";
+    public static final String LIMIT = "limit";
+
     private final long date;
     private final int lengthThreshold;
     private final List<String> languages;
@@ -48,10 +53,10 @@ public class LdbcSnbBiQuery18PersonPostCounts extends Operation<List<LdbcSnbBiQu
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("date", date)
-                .put("lengthThreshold", lengthThreshold)
-                .put("languages", languages)
-                .put("limit", limit)
+                .put(DATE, date)
+                .put(LENGTH_THRESHOLD, lengthThreshold)
+                .put(LANGUAGES, languages)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery19StrangerInteraction.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery19StrangerInteraction.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery19StrangerInteraction extends Operation<List<LdbcSnbBiQuery19StrangerInteractionResult>>
 {
@@ -41,6 +43,16 @@ public class LdbcSnbBiQuery19StrangerInteraction extends Operation<List<LdbcSnbB
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("date", date)
+                .put("tagClassA", tagClassA)
+                .put("tagClassB", tagClassB)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery19StrangerInteraction.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery19StrangerInteraction.java
@@ -12,6 +12,11 @@ public class LdbcSnbBiQuery19StrangerInteraction extends Operation<List<LdbcSnbB
 {
     public static final int TYPE = 19;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String DATE = "date";
+    public static final String TAG_CLASS1 = "tagClass1";
+    public static final String TAG_CLASS2 = "tagClass2";
+    public static final String LIMIT = "limit";
+
     private final long date;
     private final String tagClass1;
     private final String tagClass2;
@@ -48,10 +53,10 @@ public class LdbcSnbBiQuery19StrangerInteraction extends Operation<List<LdbcSnbB
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("date", date)
-                .put("tagClassA", tagClassA)
-                .put("tagClassB", tagClassB)
-                .put("limit", limit)
+                .put(DATE, date)
+                .put(TAG_CLASS1, tagClass1)
+                .put(TAG_CLASS2, tagClass2)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery1PostingSummary.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery1PostingSummary.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery1PostingSummary extends Operation<List<LdbcSnbBiQuery1PostingSummaryResult>>
 {
@@ -19,6 +21,13 @@ public class LdbcSnbBiQuery1PostingSummary extends Operation<List<LdbcSnbBiQuery
     public long date()
     {
         return date;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("date", date)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery1PostingSummary.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery1PostingSummary.java
@@ -11,6 +11,8 @@ import java.util.Map;
 public class LdbcSnbBiQuery1PostingSummary extends Operation<List<LdbcSnbBiQuery1PostingSummaryResult>>
 {
     public static final int TYPE = 1;
+    public static final String DATE = "date";
+
     private final long date;
 
     public LdbcSnbBiQuery1PostingSummary( long date )
@@ -26,7 +28,7 @@ public class LdbcSnbBiQuery1PostingSummary extends Operation<List<LdbcSnbBiQuery
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("date", date)
+                .put(DATE, date)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery20HighLevelTopics.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery20HighLevelTopics.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery20HighLevelTopics extends Operation<List<LdbcSnbBiQuery20HighLevelTopicsResult>>
 {
@@ -27,6 +29,14 @@ public class LdbcSnbBiQuery20HighLevelTopics extends Operation<List<LdbcSnbBiQue
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("tagClasses", tagClasses)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery20HighLevelTopics.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery20HighLevelTopics.java
@@ -12,6 +12,9 @@ public class LdbcSnbBiQuery20HighLevelTopics extends Operation<List<LdbcSnbBiQue
 {
     public static final int TYPE = 20;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String TAG_CLASSES = "tagClasses";
+    public static final String LIMIT = "limit";
+
     private final List<String> tagClasses;
     private final int limit;
 
@@ -34,8 +37,8 @@ public class LdbcSnbBiQuery20HighLevelTopics extends Operation<List<LdbcSnbBiQue
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("tagClasses", tagClasses)
-                .put("limit", limit)
+                .put(TAG_CLASSES, tagClasses)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery21Zombies.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery21Zombies.java
@@ -1,11 +1,13 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Map;
 
 public class LdbcSnbBiQuery21Zombies extends Operation<List<LdbcSnbBiQuery21ZombiesResult>>
 {
@@ -36,6 +38,15 @@ public class LdbcSnbBiQuery21Zombies extends Operation<List<LdbcSnbBiQuery21Zomb
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("country", country)
+                .put("endDate", endDate)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery21Zombies.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery21Zombies.java
@@ -14,6 +14,10 @@ public class LdbcSnbBiQuery21Zombies extends Operation<List<LdbcSnbBiQuery21Zomb
     public static final int TYPE = 21;
     public static final int DEFAULT_LIMIT = 100;
     public static final int DEFAULT_DAYS = 30;
+    public static final String COUNTRY = "country";
+    public static final String END_DATE = "endDate";
+    public static final String LIMIT = "limit";
+
     private final String country;
     private final long endDate;
     private final int limit;
@@ -43,9 +47,9 @@ public class LdbcSnbBiQuery21Zombies extends Operation<List<LdbcSnbBiQuery21Zomb
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("country", country)
-                .put("endDate", endDate)
-                .put("limit", limit)
+                .put(COUNTRY, country)
+                .put(END_DATE, endDate)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery22InternationalDialog.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery22InternationalDialog.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery22InternationalDialog extends Operation<List<LdbcSnbBiQuery22InternationalDialogResult>>
 {
@@ -34,6 +36,15 @@ public class LdbcSnbBiQuery22InternationalDialog extends Operation<List<LdbcSnbB
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("countryX", countryX)
+                .put("countryY", countryY)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery22InternationalDialog.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery22InternationalDialog.java
@@ -12,6 +12,10 @@ public class LdbcSnbBiQuery22InternationalDialog extends Operation<List<LdbcSnbB
 {
     public static final int TYPE = 22;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String COUNTRY1 = "country1";
+    public static final String COUNTRY2 = "country2";
+    public static final String LIMIT = "limit";
+
     private final String country1;
     private final String country2;
     private final int limit;
@@ -41,9 +45,9 @@ public class LdbcSnbBiQuery22InternationalDialog extends Operation<List<LdbcSnbB
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("countryX", countryX)
-                .put("countryY", countryY)
-                .put("limit", limit)
+                .put(COUNTRY1, country1)
+                .put(COUNTRY2, country2)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery23HolidayDestinations.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery23HolidayDestinations.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery23HolidayDestinations extends Operation<List<LdbcSnbBiQuery23HolidayDestinationsResult>>
 {
@@ -27,6 +29,14 @@ public class LdbcSnbBiQuery23HolidayDestinations extends Operation<List<LdbcSnbB
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("country", country)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery23HolidayDestinations.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery23HolidayDestinations.java
@@ -12,6 +12,9 @@ public class LdbcSnbBiQuery23HolidayDestinations extends Operation<List<LdbcSnbB
 {
     public static final int TYPE = 23;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String COUNTRY = "country";
+    public static final String LIMIT = "limit";
+
     private final String country;
     private final int limit;
 
@@ -34,8 +37,8 @@ public class LdbcSnbBiQuery23HolidayDestinations extends Operation<List<LdbcSnbB
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("country", country)
-                .put("limit", limit)
+                .put(COUNTRY, country)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery24MessagesByTopic.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery24MessagesByTopic.java
@@ -12,6 +12,9 @@ public class LdbcSnbBiQuery24MessagesByTopic extends Operation<List<LdbcSnbBiQue
 {
     public static final int TYPE = 24;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String TAG_CLASS = "tagClass";
+    public static final String LIMIT = "limit";
+
     private final String tagClass;
     private final int limit;
 
@@ -34,8 +37,8 @@ public class LdbcSnbBiQuery24MessagesByTopic extends Operation<List<LdbcSnbBiQue
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("tagClass", tagClass)
-                .put("limit", limit)
+                .put(TAG_CLASS, tagClass)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery24MessagesByTopic.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery24MessagesByTopic.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery24MessagesByTopic extends Operation<List<LdbcSnbBiQuery24MessagesByTopicResult>>
 {
@@ -27,6 +29,14 @@ public class LdbcSnbBiQuery24MessagesByTopic extends Operation<List<LdbcSnbBiQue
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("tagClass", tagClass)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery25WeightedPaths.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery25WeightedPaths.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery25WeightedPaths extends Operation<List<LdbcSnbBiQuery25WeightedPathsResult>>
 {
@@ -40,6 +42,16 @@ public class LdbcSnbBiQuery25WeightedPaths extends Operation<List<LdbcSnbBiQuery
     public long endDate()
     {
         return endDate;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("person1Id", person1Id)
+                .put("person2Id", person2Id)
+                .put("startDate", startDate)
+                .put("endDate", endDate)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery25WeightedPaths.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery25WeightedPaths.java
@@ -11,6 +11,11 @@ import java.util.Map;
 public class LdbcSnbBiQuery25WeightedPaths extends Operation<List<LdbcSnbBiQuery25WeightedPathsResult>>
 {
     public static final int TYPE = 25;
+    public static final String PERSON1_ID = "person1Id";
+    public static final String PERSON2_ID = "person2Id";
+    public static final String START_DATE = "startDate";
+    public static final String END_DATE = "endDate";
+
     private final long person1Id;
     private final long person2Id;
     private final long startDate;
@@ -47,10 +52,10 @@ public class LdbcSnbBiQuery25WeightedPaths extends Operation<List<LdbcSnbBiQuery
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("person1Id", person1Id)
-                .put("person2Id", person2Id)
-                .put("startDate", startDate)
-                .put("endDate", endDate)
+                .put(PERSON1_ID, person1Id)
+                .put(PERSON2_ID, person2Id)
+                .put(START_DATE, startDate)
+                .put(END_DATE, endDate)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery2TopTags.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery2TopTags.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery2TopTags extends Operation<List<LdbcSnbBiQuery2TopTagsResult>>
 {
@@ -53,6 +55,17 @@ public class LdbcSnbBiQuery2TopTags extends Operation<List<LdbcSnbBiQuery2TopTag
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("date1", date1)
+                .put("date2", date2)
+                .put("country1", country1)
+                .put("country2", country2)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery2TopTags.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery2TopTags.java
@@ -12,6 +12,12 @@ public class LdbcSnbBiQuery2TopTags extends Operation<List<LdbcSnbBiQuery2TopTag
 {
     public static final int TYPE = 2;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String DATE1 = "date1";
+    public static final String DATE2 = "date2";
+    public static final String COUNTRY1 = "country1";
+    public static final String COUNTRY2 = "country2";
+    public static final String LIMIT = "limit";
+
     private final long date1;
     private final long date2;
     private final String country1;
@@ -60,11 +66,11 @@ public class LdbcSnbBiQuery2TopTags extends Operation<List<LdbcSnbBiQuery2TopTag
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("date1", date1)
-                .put("date2", date2)
-                .put("country1", country1)
-                .put("country2", country2)
-                .put("limit", limit)
+                .put(DATE1, date1)
+                .put(DATE2, date2)
+                .put(COUNTRY1, country1)
+                .put(COUNTRY2, country2)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery3TagEvolution.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery3TagEvolution.java
@@ -12,6 +12,10 @@ public class LdbcSnbBiQuery3TagEvolution extends Operation<List<LdbcSnbBiQuery3T
 {
     public static final int TYPE = 3;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String YEAR = "year";
+    public static final String MONTH = "month";
+    public static final String LIMIT = "limit";
+
     private final int year;
     private final int month;
     private final int limit;
@@ -41,11 +45,9 @@ public class LdbcSnbBiQuery3TagEvolution extends Operation<List<LdbcSnbBiQuery3T
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("range1Start", range1Start)
-                .put("range1End", range1End)
-                .put("range2Start", range2Start)
-                .put("range2End", range2End)
-                .put("limit", limit)
+                .put(YEAR, year)
+                .put(MONTH, month)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery3TagEvolution.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery3TagEvolution.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery3TagEvolution extends Operation<List<LdbcSnbBiQuery3TagEvolutionResult>>
 {
@@ -34,6 +36,17 @@ public class LdbcSnbBiQuery3TagEvolution extends Operation<List<LdbcSnbBiQuery3T
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("range1Start", range1Start)
+                .put("range1End", range1End)
+                .put("range2Start", range2Start)
+                .put("range2End", range2End)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery4PopularCountryTopics.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery4PopularCountryTopics.java
@@ -12,6 +12,10 @@ public class LdbcSnbBiQuery4PopularCountryTopics extends Operation<List<LdbcSnbB
 {
     public static final int TYPE = 4;
     public static final int DEFAULT_LIMIT = 20;
+    public static final String TAG_CLASS = "tagClass";
+    public static final String COUNTRY = "country";
+    public static final String LIMIT = "limit";
+
     private final String tagClass;
     private final String country;
     private final int limit;
@@ -41,9 +45,9 @@ public class LdbcSnbBiQuery4PopularCountryTopics extends Operation<List<LdbcSnbB
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("tagClass", tagClass)
-                .put("country", country)
-                .put("limit", limit)
+                .put(TAG_CLASS, tagClass)
+                .put(COUNTRY, country)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery4PopularCountryTopics.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery4PopularCountryTopics.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery4PopularCountryTopics extends Operation<List<LdbcSnbBiQuery4PopularCountryTopicsResult>>
 {
@@ -34,6 +36,15 @@ public class LdbcSnbBiQuery4PopularCountryTopics extends Operation<List<LdbcSnbB
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("tagClass", tagClass)
+                .put("country", country)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery5TopCountryPosters.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery5TopCountryPosters.java
@@ -12,6 +12,9 @@ public class LdbcSnbBiQuery5TopCountryPosters extends Operation<List<LdbcSnbBiQu
 {
     public static final int TYPE = 5;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String COUNTRY = "country";
+    public static final String LIMIT = "limit";
+
     private final String country;
     private final int limit;
 
@@ -34,9 +37,8 @@ public class LdbcSnbBiQuery5TopCountryPosters extends Operation<List<LdbcSnbBiQu
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("country", country)
-                .put("popularForumLimit", popularForumLimit)
-                .put("limit", limit)
+                .put(COUNTRY, country)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery5TopCountryPosters.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery5TopCountryPosters.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery5TopCountryPosters extends Operation<List<LdbcSnbBiQuery5TopCountryPostersResult>>
 {
@@ -27,6 +29,15 @@ public class LdbcSnbBiQuery5TopCountryPosters extends Operation<List<LdbcSnbBiQu
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("country", country)
+                .put("popularForumLimit", popularForumLimit)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery6ActivePosters.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery6ActivePosters.java
@@ -12,6 +12,9 @@ public class LdbcSnbBiQuery6ActivePosters extends Operation<List<LdbcSnbBiQuery6
 {
     public static final int TYPE = 6;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String TAG = "tag";
+    public static final String LIMIT = "limit";
+
     private final String tag;
     private final int limit;
 
@@ -34,8 +37,8 @@ public class LdbcSnbBiQuery6ActivePosters extends Operation<List<LdbcSnbBiQuery6
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("tag", tag)
-                .put("limit", limit)
+                .put(TAG, tag)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery6ActivePosters.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery6ActivePosters.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery6ActivePosters extends Operation<List<LdbcSnbBiQuery6ActivePostersResult>>
 {
@@ -27,6 +29,14 @@ public class LdbcSnbBiQuery6ActivePosters extends Operation<List<LdbcSnbBiQuery6
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("tag", tag)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery7AuthoritativeUsers.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery7AuthoritativeUsers.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery7AuthoritativeUsers extends Operation<List<LdbcSnbBiQuery7AuthoritativeUsersResult>>
 {
@@ -27,6 +29,14 @@ public class LdbcSnbBiQuery7AuthoritativeUsers extends Operation<List<LdbcSnbBiQ
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("tag", tag)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery7AuthoritativeUsers.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery7AuthoritativeUsers.java
@@ -12,6 +12,9 @@ public class LdbcSnbBiQuery7AuthoritativeUsers extends Operation<List<LdbcSnbBiQ
 {
     public static final int TYPE = 7;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String TAG = "tag";
+    public static final String LIMIT = "limit";
+
     private final String tag;
     private final int limit;
 
@@ -34,8 +37,8 @@ public class LdbcSnbBiQuery7AuthoritativeUsers extends Operation<List<LdbcSnbBiQ
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("tag", tag)
-                .put("limit", limit)
+                .put(TAG, tag)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery8RelatedTopics.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery8RelatedTopics.java
@@ -12,6 +12,9 @@ public class LdbcSnbBiQuery8RelatedTopics extends Operation<List<LdbcSnbBiQuery8
 {
     public static final int TYPE = 8;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String TAG = "tag";
+    public static final String LIMIT = "limit";
+
     private final String tag;
     private final int limit;
 
@@ -34,8 +37,8 @@ public class LdbcSnbBiQuery8RelatedTopics extends Operation<List<LdbcSnbBiQuery8
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("tag", tag)
-                .put("limit", limit)
+                .put(TAG, tag)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery8RelatedTopics.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery8RelatedTopics.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery8RelatedTopics extends Operation<List<LdbcSnbBiQuery8RelatedTopicsResult>>
 {
@@ -27,6 +29,14 @@ public class LdbcSnbBiQuery8RelatedTopics extends Operation<List<LdbcSnbBiQuery8
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("tag", tag)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery9RelatedForums.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery9RelatedForums.java
@@ -12,6 +12,11 @@ public class LdbcSnbBiQuery9RelatedForums extends Operation<List<LdbcSnbBiQuery9
 {
     public static final int TYPE = 9;
     public static final int DEFAULT_LIMIT = 100;
+    public static final String TAG_CLASS1 = "tagClass1";
+    public static final String TAG_CLASS2 = "tagClass2";
+    public static final String THRESHOLD = "threshold";
+    public static final String LIMIT = "limit";
+
     private final String tagClass1;
     private final String tagClass2;
     private final int threshold;
@@ -48,10 +53,10 @@ public class LdbcSnbBiQuery9RelatedForums extends Operation<List<LdbcSnbBiQuery9
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("tagClassA", tagClassA)
-                .put("tagClassB", tagClassB)
-                .put("threshold", threshold)
-                .put("limit", limit)
+                .put(TAG_CLASS1, tagClass1)
+                .put(TAG_CLASS2, tagClass2)
+                .put(THRESHOLD, threshold)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery9RelatedForums.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiQuery9RelatedForums.java
@@ -1,10 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class LdbcSnbBiQuery9RelatedForums extends Operation<List<LdbcSnbBiQuery9RelatedForumsResult>>
 {
@@ -41,6 +43,16 @@ public class LdbcSnbBiQuery9RelatedForums extends Operation<List<LdbcSnbBiQuery9
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("tagClassA", tagClassA)
+                .put("tagClassB", tagClassB)
+                .put("threshold", threshold)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery1.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery1.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
@@ -9,6 +10,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -42,6 +44,15 @@ public class LdbcQuery1 extends Operation<List<LdbcQuery1Result>>
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("firstName", firstName)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery1.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery1.java
@@ -24,6 +24,10 @@ public class LdbcQuery1 extends Operation<List<LdbcQuery1Result>>
     private final String firstName;
     private final int limit;
 
+    public static final String PERSON_ID = "personId";
+    public static final String FIRST_NAME = "firstName";
+    public static final String LIMIT = "limit";
+
     public LdbcQuery1( long personId, String firstName, int limit )
     {
         this.personId = personId;
@@ -49,9 +53,9 @@ public class LdbcQuery1 extends Operation<List<LdbcQuery1Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("firstName", firstName)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(FIRST_NAME, firstName)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery10.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery10.java
@@ -19,6 +19,10 @@ public class LdbcQuery10 extends Operation<List<LdbcQuery10Result>>
 
     public static final int TYPE = 10;
     public static final int DEFAULT_LIMIT = 10;
+    public static final String PERSON_ID = "personId";
+    public static final String MONTH = "month";
+    public static final String LIMIT = "limit";
+
     private final long personId;
     private final int month;
     private final int limit;
@@ -49,9 +53,9 @@ public class LdbcQuery10 extends Operation<List<LdbcQuery10Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("month", month)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(MONTH, month)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery10.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery10.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -41,6 +43,16 @@ public class LdbcQuery10 extends Operation<List<LdbcQuery10Result>>
     public int limit()
     {
         return limit;
+    }
+
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("month", month)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery11.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery11.java
@@ -19,6 +19,11 @@ public class LdbcQuery11 extends Operation<List<LdbcQuery11Result>>
 
     public static final int TYPE = 11;
     public static final int DEFAULT_LIMIT = 10;
+    public static final String PERSON_ID = "personId";
+    public static final String COUNTRY_NAME = "countryName";
+    public static final String WORK_FROM_YEAR = "workFromYear";
+    public static final String LIMIT = "limit";
+
     private final long personId;
     private final String countryName;
     private final int workFromYear;
@@ -55,10 +60,10 @@ public class LdbcQuery11 extends Operation<List<LdbcQuery11Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("countryName", countryName)
-                .put("workFromYear", workFromYear)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(COUNTRY_NAME, countryName)
+                .put(WORK_FROM_YEAR, workFromYear)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery11.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery11.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -48,6 +50,16 @@ public class LdbcQuery11 extends Operation<List<LdbcQuery11Result>>
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("countryName", countryName)
+                .put("workFromYear", workFromYear)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery12.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery12.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -41,6 +43,15 @@ public class LdbcQuery12 extends Operation<List<LdbcQuery12Result>>
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("tagClassName", tagClassName)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery12.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery12.java
@@ -19,6 +19,10 @@ public class LdbcQuery12 extends Operation<List<LdbcQuery12Result>>
 
     public static final int TYPE = 12;
     public static final int DEFAULT_LIMIT = 20;
+    public static final String PERSON_ID = "personId";
+    public static final String TAG_CLASS_NAME = "tagClassName";
+    public static final String LIMIT = "limit";
+
     private final long personId;
     private final String tagClassName;
     private final int limit;
@@ -48,9 +52,9 @@ public class LdbcQuery12 extends Operation<List<LdbcQuery12Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("tagClassName", tagClassName)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(TAG_CLASS_NAME, tagClassName)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery13.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery13.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -33,6 +35,14 @@ public class LdbcQuery13 extends Operation<LdbcQuery13Result>
     public long person2Id()
     {
         return person2Id;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("person1Id", person1Id)
+                .put("person2Id", person2Id)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery13.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery13.java
@@ -18,6 +18,9 @@ public class LdbcQuery13 extends Operation<LdbcQuery13Result>
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     public static final int TYPE = 13;
+    public static final String PERSON1_ID = "person1Id";
+    public static final String PERSON2_ID = "person2Id";
+
     private final long person1Id;
     private final long person2Id;
 
@@ -40,8 +43,8 @@ public class LdbcQuery13 extends Operation<LdbcQuery13Result>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("person1Id", person1Id)
-                .put("person2Id", person2Id)
+                .put(PERSON1_ID, person1Id)
+                .put(PERSON2_ID, person2Id)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery14.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery14.java
@@ -1,6 +1,7 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
@@ -10,6 +11,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -35,6 +37,14 @@ public class LdbcQuery14 extends Operation<List<LdbcQuery14Result>>
     public long person2Id()
     {
         return person2Id;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("person1Id", person1Id)
+                .put("person2Id()", person2Id())
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery14.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery14.java
@@ -20,6 +20,9 @@ public class LdbcQuery14 extends Operation<List<LdbcQuery14Result>>
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     public static final int TYPE = 14;
+    public static final String PERSON1_ID = "person1Id";
+    public static final String PERSON2_ID = "person2Id";
+
     private final long person1Id;
     private final long person2Id;
 
@@ -42,8 +45,8 @@ public class LdbcQuery14 extends Operation<List<LdbcQuery14Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("person1Id", person1Id)
-                .put("person2Id()", person2Id())
+                .put(PERSON1_ID, person1Id)
+                .put(PERSON2_ID, person2Id)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery2.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery2.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -43,6 +45,15 @@ public class LdbcQuery2 extends Operation<List<LdbcQuery2Result>>
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("maxDate", maxDate)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery2.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery2.java
@@ -24,6 +24,10 @@ public class LdbcQuery2 extends Operation<List<LdbcQuery2Result>>
     private final Date maxDate;
     private final int limit;
 
+    public static String PERSON_ID = "personId";
+    public static String MAX_DATE = "maxDate";
+    public static String LIMIT = "limit";
+
     public LdbcQuery2( long personId, Date maxDate, int limit )
     {
         super();
@@ -50,9 +54,9 @@ public class LdbcQuery2 extends Operation<List<LdbcQuery2Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("maxDate", maxDate)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(MAX_DATE, maxDate)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery3.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery3.java
@@ -27,6 +27,13 @@ public class LdbcQuery3 extends Operation<List<LdbcQuery3Result>>
     private final int durationDays;
     private final int limit;
 
+    public static final String PERSON_ID = "personId";
+    public static final String COUNTRY_X_NAME  = "countryXName";
+    public static final String COUNTRY_Y_NAME  = "countryYName";
+    public static final String START_DATE = "startDate";
+    public static final String DURATION_DAYS= "durationDays";
+    public static final String LIMIT = "limit";
+
     public LdbcQuery3( long personId, String countryXName, String countryYName, Date startDate, int durationDays,
             int limit )
     {
@@ -71,12 +78,12 @@ public class LdbcQuery3 extends Operation<List<LdbcQuery3Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-            .put("personId", personId)
-            .put("countryXName", countryXName)
-            .put("countryYName", countryYName)
-            .put("startDate", startDate)
-            .put("durationDays", durationDays)
-            .put("limit", limit)
+            .put(PERSON_ID, personId)
+            .put(COUNTRY_X_NAME, countryXName)
+            .put(COUNTRY_Y_NAME, countryYName)
+            .put(START_DATE, startDate)
+            .put(DURATION_DAYS, durationDays)
+            .put(LIMIT, limit)
             .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery3.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery3.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -64,6 +66,18 @@ public class LdbcQuery3 extends Operation<List<LdbcQuery3Result>>
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+            .put("personId", personId)
+            .put("countryXName", countryXName)
+            .put("countryYName", countryYName)
+            .put("startDate", startDate)
+            .put("durationDays", durationDays)
+            .put("limit", limit)
+            .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery4.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery4.java
@@ -25,6 +25,11 @@ public class LdbcQuery4 extends Operation<List<LdbcQuery4Result>>
     private final int durationDays;
     private final int limit;
 
+    private static final String PERSON_ID = "personId";
+    private static final String START_DATE = "startDate";
+    private static final String DURATION_DAYS = "durationDays";
+    private static final String LIMIT = "limit";
+
     public LdbcQuery4( long personId, Date startDate, int durationDays, int limit )
     {
         this.personId = personId;
@@ -56,10 +61,10 @@ public class LdbcQuery4 extends Operation<List<LdbcQuery4Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("startDate", startDate)
-                .put("durationDays", durationDays)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(START_DATE, startDate)
+                .put(DURATION_DAYS, durationDays)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery4.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery4.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -49,6 +51,16 @@ public class LdbcQuery4 extends Operation<List<LdbcQuery4Result>>
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("startDate", startDate)
+                .put("durationDays", durationDays)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery5.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery5.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -43,6 +45,15 @@ public class LdbcQuery5 extends Operation<List<LdbcQuery5Result>>
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("minDate", minDate)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery5.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery5.java
@@ -24,6 +24,10 @@ public class LdbcQuery5 extends Operation<List<LdbcQuery5Result>>
     private final Date minDate;
     private final int limit;
 
+    public static final String PERSON_ID = "personId";
+    public static final String MIN_DATE = "minDate";
+    public static final String LIMIT = "limit";
+
     public LdbcQuery5( long personId, Date minDate, int limit )
     {
         super();
@@ -50,9 +54,9 @@ public class LdbcQuery5 extends Operation<List<LdbcQuery5Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("minDate", minDate)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(MIN_DATE, minDate)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery6.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery6.java
@@ -23,6 +23,10 @@ public class LdbcQuery6 extends Operation<List<LdbcQuery6Result>>
     private final String tagName;
     private final int limit;
 
+    public static final String PERSON_ID = "personId";
+    public static final String TAG_NAME = "tagName";
+    public static final String LIMIT = "limit";
+
     public LdbcQuery6( long personId, String tagName, int limit )
     {
         this.personId = personId;
@@ -49,9 +53,9 @@ public class LdbcQuery6 extends Operation<List<LdbcQuery6Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("tagName", tagName)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(TAG_NAME, tagName)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery6.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery6.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -41,6 +43,16 @@ public class LdbcQuery6 extends Operation<List<LdbcQuery6Result>>
     public int limit()
     {
         return limit;
+    }
+
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("tagName", tagName)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery7.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery7.java
@@ -19,6 +19,9 @@ public class LdbcQuery7 extends Operation<List<LdbcQuery7Result>>
 
     public static final int TYPE = 7;
     public static final int DEFAULT_LIMIT = 20;
+    public static final String PERSON_ID = "personId";
+    public static final String LIMIT = "limit";
+
     private final long personId;
     private final int limit;
 
@@ -39,12 +42,11 @@ public class LdbcQuery7 extends Operation<List<LdbcQuery7Result>>
         return limit;
     }
 
-
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery7.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery7.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -35,6 +37,15 @@ public class LdbcQuery7 extends Operation<List<LdbcQuery7Result>>
     public int limit()
     {
         return limit;
+    }
+
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery8.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery8.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -35,6 +37,15 @@ public class LdbcQuery8 extends Operation<List<LdbcQuery8Result>>
     public int limit()
     {
         return limit;
+    }
+
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery8.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery8.java
@@ -19,6 +19,9 @@ public class LdbcQuery8 extends Operation<List<LdbcQuery8Result>>
 
     public static final int TYPE = 8;
     public static final int DEFAULT_LIMIT = 20;
+    public static final String PERSON_ID = "personId";
+    public static final String LIMIT = "limit";
+
     private final long personId;
     private final int limit;
 
@@ -43,8 +46,8 @@ public class LdbcQuery8 extends Operation<List<LdbcQuery8Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery9.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery9.java
@@ -20,6 +20,10 @@ public class LdbcQuery9 extends Operation<List<LdbcQuery9Result>>
 
     public static final int TYPE = 9;
     public static final int DEFAULT_LIMIT = 20;
+    public static final String PERSON_ID = "personId";
+    public static final String MAX_DATE = "maxDate";
+    public static final String LIMIT = "limit";
+
     private final long personId;
     private final Date maxDate;
     private final int limit;
@@ -49,9 +53,9 @@ public class LdbcQuery9 extends Operation<List<LdbcQuery9Result>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("maxDate", maxDate)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(MAX_DATE, maxDate)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery9.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery9.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -42,6 +44,15 @@ public class LdbcQuery9 extends Operation<List<LdbcQuery9Result>>
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("maxDate", maxDate)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery1PersonProfile.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery1PersonProfile.java
@@ -17,6 +17,8 @@ public class LdbcShortQuery1PersonProfile extends Operation<LdbcShortQuery1Perso
 {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     public static final int TYPE = 101;
+    public static final String PERSON_ID = "personId";
+
     private final long personId;
 
     public LdbcShortQuery1PersonProfile( long personId )
@@ -33,7 +35,7 @@ public class LdbcShortQuery1PersonProfile extends Operation<LdbcShortQuery1Perso
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
+                .put(PERSON_ID, personId)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery1PersonProfile.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery1PersonProfile.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -25,6 +27,14 @@ public class LdbcShortQuery1PersonProfile extends Operation<LdbcShortQuery1Perso
     public long personId()
     {
         return personId;
+    }
+
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery2PersonPosts.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery2PersonPosts.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -33,6 +35,14 @@ public class LdbcShortQuery2PersonPosts extends Operation<List<LdbcShortQuery2Pe
     public int limit()
     {
         return limit;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("limit", limit)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery2PersonPosts.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery2PersonPosts.java
@@ -18,6 +18,9 @@ public class LdbcShortQuery2PersonPosts extends Operation<List<LdbcShortQuery2Pe
     public static final int TYPE = 102;
     public static final int DEFAULT_LIMIT = 10;
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    public static final String PERSON_ID = "personId";
+    public static final String LIMIT = "limit";
+
     private final long personId;
     private final int limit;
 
@@ -40,8 +43,8 @@ public class LdbcShortQuery2PersonPosts extends Operation<List<LdbcShortQuery2Pe
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("limit", limit)
+                .put(PERSON_ID, personId)
+                .put(LIMIT, limit)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery3PersonFriends.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery3PersonFriends.java
@@ -17,6 +17,8 @@ public class LdbcShortQuery3PersonFriends extends Operation<List<LdbcShortQuery3
 {
     public static final int TYPE = 103;
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    public static final String PERSON_ID = "personId";
+
     private final long personId;
 
     public LdbcShortQuery3PersonFriends( long personId )
@@ -32,7 +34,7 @@ public class LdbcShortQuery3PersonFriends extends Operation<List<LdbcShortQuery3
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
+                .put(PERSON_ID, personId)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery3PersonFriends.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery3PersonFriends.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -25,6 +27,13 @@ public class LdbcShortQuery3PersonFriends extends Operation<List<LdbcShortQuery3
     public long personId()
     {
         return personId;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery4MessageContent.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery4MessageContent.java
@@ -17,6 +17,8 @@ public class LdbcShortQuery4MessageContent extends Operation<LdbcShortQuery4Mess
 {
     public static final int TYPE = 104;
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    public static final String MESSAGE_ID = "messageId";
+
     private final long messageId;
 
     public LdbcShortQuery4MessageContent( long messageId )
@@ -32,7 +34,7 @@ public class LdbcShortQuery4MessageContent extends Operation<LdbcShortQuery4Mess
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("messageId", messageId)
+                .put(MESSAGE_ID, messageId)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery4MessageContent.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery4MessageContent.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -25,6 +27,13 @@ public class LdbcShortQuery4MessageContent extends Operation<LdbcShortQuery4Mess
     public long messageId()
     {
         return messageId;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("messageId", messageId)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery5MessageCreator.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery5MessageCreator.java
@@ -17,6 +17,8 @@ public class LdbcShortQuery5MessageCreator extends Operation<LdbcShortQuery5Mess
 {
     public static final int TYPE = 105;
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    public static final String MESSAGE_ID = "messageId";
+
     private final long messageId;
 
     public LdbcShortQuery5MessageCreator( long messageId )
@@ -32,7 +34,7 @@ public class LdbcShortQuery5MessageCreator extends Operation<LdbcShortQuery5Mess
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("messageId", messageId)
+                .put(MESSAGE_ID, messageId)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery5MessageCreator.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery5MessageCreator.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -25,6 +27,13 @@ public class LdbcShortQuery5MessageCreator extends Operation<LdbcShortQuery5Mess
     public long messageId()
     {
         return messageId;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("messageId", messageId)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery6MessageForum.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery6MessageForum.java
@@ -17,6 +17,8 @@ public class LdbcShortQuery6MessageForum extends Operation<LdbcShortQuery6Messag
 {
     public static final int TYPE = 106;
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    public static final String MESSAGE_ID = "messageId";
+
     private final long messageId;
 
     public LdbcShortQuery6MessageForum( long messageId )
@@ -32,7 +34,7 @@ public class LdbcShortQuery6MessageForum extends Operation<LdbcShortQuery6Messag
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("messageId", messageId)
+                .put(MESSAGE_ID, messageId)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery6MessageForum.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery6MessageForum.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -25,6 +27,13 @@ public class LdbcShortQuery6MessageForum extends Operation<LdbcShortQuery6Messag
     public long messageId()
     {
         return messageId;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("messageId", messageId)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery7MessageReplies.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery7MessageReplies.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -8,6 +9,7 @@ import org.codehaus.jackson.type.TypeReference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -25,6 +27,13 @@ public class LdbcShortQuery7MessageReplies extends Operation<List<LdbcShortQuery
     public long messageId()
     {
         return messageId;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("messageId", messageId)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery7MessageReplies.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery7MessageReplies.java
@@ -17,6 +17,8 @@ public class LdbcShortQuery7MessageReplies extends Operation<List<LdbcShortQuery
 {
     public static final int TYPE = 107;
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    public static final String MESSAGE_ID = "messageId";
+
     private final long messageId;
 
     public LdbcShortQuery7MessageReplies( long messageId )
@@ -32,7 +34,7 @@ public class LdbcShortQuery7MessageReplies extends Operation<List<LdbcShortQuery
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("messageId", messageId)
+                .put(MESSAGE_ID, messageId)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate1AddPerson.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate1AddPerson.java
@@ -18,6 +18,21 @@ public class LdbcUpdate1AddPerson extends Operation<LdbcNoResult>
 {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     public static final int TYPE = 1001;
+    public static final String PERSON_ID = "personId";
+    public static final String PERSON_FIRST_NAME = "personFirstName";
+    public static final String PERSON_LAST_NAME = "personLastName";
+    public static final String GENDER = "gender";
+    public static final String BIRTHDAY = "birthday";
+    public static final String CREATION_DATE = "creationDate";
+    public static final String LOCATION_IP = "locationIp";
+    public static final String BROWSER_USED = "browserUsed";
+    public static final String CITY_ID = "cityId";
+    public static final String LANGUAGES = "languages";
+    public static final String EMAILS = "emails";
+    public static final String TAG_IDS = "tagIds";
+    public static final String STUDY_AT = "studyAt";
+    public static final String WORK_AT = "workAt";
+
     private final long personId;
     private final String personFirstName;
     private final String personLastName;
@@ -137,20 +152,20 @@ public class LdbcUpdate1AddPerson extends Operation<LdbcNoResult>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("personFirstName", personFirstName)
-                .put("personLastName", personLastName)
-                .put("gender", gender)
-                .put("birthday", birthday)
-                .put("creationDate", creationDate)
-                .put("locationIp", locationIp)
-                .put("browserUsed", browserUsed)
-                .put("cityId", cityId)
-                .put("languages", languages)
-                .put("emails", emails)
-                .put("tagIds", tagIds)
-                .put("studyAt", studyAt)
-                .put("workAt", workAt)
+                .put(PERSON_ID, personId)
+                .put(PERSON_FIRST_NAME, personFirstName)
+                .put(PERSON_LAST_NAME, personLastName)
+                .put(GENDER, gender)
+                .put(BIRTHDAY, birthday)
+                .put(CREATION_DATE, creationDate)
+                .put(LOCATION_IP, locationIp)
+                .put(BROWSER_USED, browserUsed)
+                .put(CITY_ID, cityId)
+                .put(LANGUAGES, languages)
+                .put(EMAILS, emails)
+                .put(TAG_IDS, tagIds)
+                .put(STUDY_AT, studyAt)
+                .put(WORK_AT, workAt)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate1AddPerson.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate1AddPerson.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import com.ldbc.driver.util.ListUtils;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -130,6 +132,26 @@ public class LdbcUpdate1AddPerson extends Operation<LdbcNoResult>
     public List<Organization> workAt()
     {
         return workAt;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("personFirstName", personFirstName)
+                .put("personLastName", personLastName)
+                .put("gender", gender)
+                .put("birthday", birthday)
+                .put("creationDate", creationDate)
+                .put("locationIp", locationIp)
+                .put("browserUsed", browserUsed)
+                .put("cityId", cityId)
+                .put("languages", languages)
+                .put("emails", emails)
+                .put("tagIds", tagIds)
+                .put("studyAt", studyAt)
+                .put("workAt", workAt)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate2AddPostLike.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate2AddPostLike.java
@@ -1,11 +1,13 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -37,6 +39,15 @@ public class LdbcUpdate2AddPostLike extends Operation<LdbcNoResult>
     public Date creationDate()
     {
         return creationDate;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("postId", postId)
+                .put("creationDate", creationDate)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate2AddPostLike.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate2AddPostLike.java
@@ -15,6 +15,10 @@ public class LdbcUpdate2AddPostLike extends Operation<LdbcNoResult>
 {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     public static final int TYPE = 1002;
+    public static final String PERSON_ID = "personId";
+    public static final String POST_ID = "postId";
+    public static final String CREATION_DATE = "creationDate";
+
     private final long personId;
     private final long postId;
     private final Date creationDate;
@@ -44,9 +48,9 @@ public class LdbcUpdate2AddPostLike extends Operation<LdbcNoResult>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("postId", postId)
-                .put("creationDate", creationDate)
+                .put(PERSON_ID, personId)
+                .put(POST_ID, postId)
+                .put(CREATION_DATE, creationDate)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate3AddCommentLike.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate3AddCommentLike.java
@@ -1,11 +1,13 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -37,6 +39,15 @@ public class LdbcUpdate3AddCommentLike extends Operation<LdbcNoResult>
     public Date creationDate()
     {
         return creationDate;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("personId", personId)
+                .put("commentId", commentId)
+                .put("creationDate", creationDate)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate3AddCommentLike.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate3AddCommentLike.java
@@ -15,6 +15,10 @@ public class LdbcUpdate3AddCommentLike extends Operation<LdbcNoResult>
 {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     public static final int TYPE = 1003;
+    public static final String PERSON_ID = "personId";
+    public static final String COMMENT_ID = "commentId";
+    public static final String CREATION_DATE = "creationDate";
+
     private final long personId;
     private final long commentId;
     private final Date creationDate;
@@ -44,9 +48,9 @@ public class LdbcUpdate3AddCommentLike extends Operation<LdbcNoResult>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("personId", personId)
-                .put("commentId", commentId)
-                .put("creationDate", creationDate)
+                .put(PERSON_ID, personId)
+                .put(COMMENT_ID, commentId)
+                .put(CREATION_DATE, creationDate)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate4AddForum.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate4AddForum.java
@@ -18,6 +18,12 @@ public class LdbcUpdate4AddForum extends Operation<LdbcNoResult>
 {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     public static final int TYPE = 1004;
+    public static final String FORUM_ID = "forumId";
+    public static final String FORUM_TITLE = "forumTitle";
+    public static final String CREATION_DATE = "creationDate";
+    public static final String MODERATOR_PERSON_ID = "moderatorPersonId";
+    public static final String TAG_IDS = "tagIds";
+
     private final long forumId;
     private final String forumTitle;
     private final Date creationDate;
@@ -62,11 +68,11 @@ public class LdbcUpdate4AddForum extends Operation<LdbcNoResult>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("forumId", forumId)
-                .put("forumTitle", forumTitle)
-                .put("creationDate", creationDate)
-                .put("moderatorPersonId", moderatorPersonId)
-                .put("tagIds", tagIds)
+                .put(FORUM_ID, forumId)
+                .put(FORUM_TITLE, forumTitle)
+                .put(CREATION_DATE, creationDate)
+                .put(MODERATOR_PERSON_ID, moderatorPersonId)
+                .put(TAG_IDS, tagIds)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate4AddForum.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate4AddForum.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import com.ldbc.driver.util.ListUtils;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -55,6 +57,17 @@ public class LdbcUpdate4AddForum extends Operation<LdbcNoResult>
     public List<Long> tagIds()
     {
         return tagIds;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("forumId", forumId)
+                .put("forumTitle", forumTitle)
+                .put("creationDate", creationDate)
+                .put("moderatorPersonId", moderatorPersonId)
+                .put("tagIds", tagIds)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate5AddForumMembership.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate5AddForumMembership.java
@@ -15,6 +15,10 @@ public class LdbcUpdate5AddForumMembership extends Operation<LdbcNoResult>
 {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     public static final int TYPE = 1005;
+    public static final String FORUM_ID = "forumId";
+    public static final String PERSON_ID = "personId";
+    public static final String JOIN_DATE = "joinDate";
+
     private final long forumId;
     private final long personId;
     private final Date joinDate;
@@ -44,9 +48,9 @@ public class LdbcUpdate5AddForumMembership extends Operation<LdbcNoResult>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("forumId", forumId)
-                .put("personId", personId)
-                .put("joinDate", joinDate)
+                .put(FORUM_ID, forumId)
+                .put(PERSON_ID, personId)
+                .put(JOIN_DATE, joinDate)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate5AddForumMembership.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate5AddForumMembership.java
@@ -1,11 +1,13 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -37,6 +39,15 @@ public class LdbcUpdate5AddForumMembership extends Operation<LdbcNoResult>
     public Date joinDate()
     {
         return joinDate;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("forumId", forumId)
+                .put("personId", personId)
+                .put("joinDate", joinDate)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate6AddPost.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate6AddPost.java
@@ -18,6 +18,19 @@ public class LdbcUpdate6AddPost extends Operation<LdbcNoResult>
 {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     public static final int TYPE = 1006;
+    public static final String POST_ID = "postId";
+    public static final String IMAGE_FILE = "imageFile";
+    public static final String CREATION_DATE = "creationDate";
+    public static final String LOCATION_IP = "locationIp";
+    public static final String BROWSER_USED = "browserUsed";
+    public static final String LANGUAGE = "language";
+    public static final String CONTENT = "content";
+    public static final String LENGTH = "length";
+    public static final String AUTHOR_PERSON_ID = "authorPersonId";
+    public static final String FORUM_ID = "forumId";
+    public static final String COUNTRY_ID = "countryId";
+    public static final String TAG_IDS = "tagIds";
+
     private final long postId;
     private final String imageFile;
     private final Date creationDate;
@@ -121,18 +134,18 @@ public class LdbcUpdate6AddPost extends Operation<LdbcNoResult>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("postId", postId)
-                .put("imageFile", imageFile)
-                .put("creationDate", creationDate)
-                .put("locationIp", locationIp)
-                .put("browserUsed", browserUsed)
-                .put("language", language)
-                .put("content", content)
-                .put("length", length)
-                .put("authorPersonId", authorPersonId)
-                .put("forumId", forumId)
-                .put("countryId", countryId)
-                .put("tagIds", tagIds)
+                .put(POST_ID, postId)
+                .put(IMAGE_FILE, imageFile)
+                .put(CREATION_DATE, creationDate)
+                .put(LOCATION_IP, locationIp)
+                .put(BROWSER_USED, browserUsed)
+                .put(LANGUAGE, language)
+                .put(CONTENT, content)
+                .put(LENGTH, length)
+                .put(AUTHOR_PERSON_ID, authorPersonId)
+                .put(FORUM_ID, forumId)
+                .put(COUNTRY_ID, countryId)
+                .put(TAG_IDS, tagIds)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate6AddPost.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate6AddPost.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import com.ldbc.driver.util.ListUtils;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -114,6 +116,24 @@ public class LdbcUpdate6AddPost extends Operation<LdbcNoResult>
     public List<Long> tagIds()
     {
         return tagIds;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("postId", postId)
+                .put("imageFile", imageFile)
+                .put("creationDate", creationDate)
+                .put("locationIp", locationIp)
+                .put("browserUsed", browserUsed)
+                .put("language", language)
+                .put("content", content)
+                .put("length", length)
+                .put("authorPersonId", authorPersonId)
+                .put("forumId", forumId)
+                .put("countryId", countryId)
+                .put("tagIds", tagIds)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate7AddComment.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate7AddComment.java
@@ -18,6 +18,18 @@ public class LdbcUpdate7AddComment extends Operation<LdbcNoResult>
 {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     public static final int TYPE = 1007;
+    public static final String COMMENT_ID = "commentId";
+    public static final String CREATION_DATE = "creationDate";
+    public static final String LOCATION_IP = "locationIp";
+    public static final String BROWSER_USED = "browserUsed";
+    public static final String CONTENT = "content";
+    public static final String LENGTH = "length";
+    public static final String AUTHOR_PERSON_ID = "authorPersonId";
+    public static final String COUNTRY_ID = "countryId";
+    public static final String REPLY_TO_POST_ID = "replyToPostId";
+    public static final String REPLY_TO_COMMENT_ID = "replyToCommentId";
+    public static final String TAG_IDS = "tagIds";
+
     private final long commentId;
     private final Date creationDate;
     private final String locationIp;
@@ -113,17 +125,17 @@ public class LdbcUpdate7AddComment extends Operation<LdbcNoResult>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("commentId", commentId)
-                .put("creationDate", creationDate)
-                .put("locationIp", locationIp)
-                .put("browserUsed", browserUsed)
-                .put("content", content)
-                .put("length", length)
-                .put("authorPersonId", authorPersonId)
-                .put("countryId", countryId)
-                .put("replyToPostId", replyToPostId)
-                .put("replyToCommentId", replyToCommentId)
-                .put("tagIds", tagIds)
+                .put(COMMENT_ID, commentId)
+                .put(CREATION_DATE, creationDate)
+                .put(LOCATION_IP, locationIp)
+                .put(BROWSER_USED, browserUsed)
+                .put(CONTENT, content)
+                .put(LENGTH, length)
+                .put(AUTHOR_PERSON_ID, authorPersonId)
+                .put(COUNTRY_ID, countryId)
+                .put(REPLY_TO_POST_ID, replyToPostId)
+                .put(REPLY_TO_COMMENT_ID, replyToCommentId)
+                .put(TAG_IDS, tagIds)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate7AddComment.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate7AddComment.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import com.ldbc.driver.util.ListUtils;
@@ -9,6 +10,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -106,6 +108,23 @@ public class LdbcUpdate7AddComment extends Operation<LdbcNoResult>
     public List<Long> tagIds()
     {
         return tagIds;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("commentId", commentId)
+                .put("creationDate", creationDate)
+                .put("locationIp", locationIp)
+                .put("browserUsed", browserUsed)
+                .put("content", content)
+                .put("length", length)
+                .put("authorPersonId", authorPersonId)
+                .put("countryId", countryId)
+                .put("replyToPostId", replyToPostId)
+                .put("replyToCommentId", replyToCommentId)
+                .put("tagIds", tagIds)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate8AddFriendship.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate8AddFriendship.java
@@ -1,11 +1,13 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.Map;
 
 import static java.lang.String.format;
 
@@ -37,6 +39,16 @@ public class LdbcUpdate8AddFriendship extends Operation<LdbcNoResult>
     public Date creationDate()
     {
         return creationDate;
+    }
+
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("person1Id", person1Id)
+                .put("person2Id", person2Id)
+                .put("creationDate", creationDate)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate8AddFriendship.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate8AddFriendship.java
@@ -15,6 +15,10 @@ public class LdbcUpdate8AddFriendship extends Operation<LdbcNoResult>
 {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     public static final int TYPE = 1008;
+    public static final String PERSON1_ID = "person1Id";
+    public static final String PERSON2_ID = "person2Id";
+    public static final String CREATION_DATE = "creationDate";
+
     private final long person1Id;
     private final long person2Id;
     private final Date creationDate;
@@ -45,9 +49,9 @@ public class LdbcUpdate8AddFriendship extends Operation<LdbcNoResult>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("person1Id", person1Id)
-                .put("person2Id", person2Id)
-                .put("creationDate", creationDate)
+                .put(PERSON1_ID, person1Id)
+                .put(PERSON2_ID, person2Id)
+                .put(CREATION_DATE, creationDate)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/simple/InsertOperation.java
+++ b/src/main/java/com/ldbc/driver/workloads/simple/InsertOperation.java
@@ -9,6 +9,9 @@ import java.util.Map;
 public class InsertOperation extends Operation<Object>
 {
     public static final int TYPE = 2;
+    public static final String TABLE = "table";
+    public static final String KEY = "key";
+    public static final String VALUES = "VALUES";
 
     private final String table;
     private final String key;
@@ -40,9 +43,9 @@ public class InsertOperation extends Operation<Object>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("table", table)
-                .put("key", key)
-                .put("fields", values)
+                .put(TABLE, table)
+                .put(KEY, key)
+                .put(VALUES, values)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/simple/InsertOperation.java
+++ b/src/main/java/com/ldbc/driver/workloads/simple/InsertOperation.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.simple;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 
 import java.util.Iterator;
@@ -34,6 +35,15 @@ public class InsertOperation extends Operation<Object>
     public Map<String,Iterator<Byte>> fields()
     {
         return values;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("table", table)
+                .put("key", key)
+                .put("fields", values)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/simple/ReadModifyWriteOperation.java
+++ b/src/main/java/com/ldbc/driver/workloads/simple/ReadModifyWriteOperation.java
@@ -10,6 +10,10 @@ import java.util.Map;
 public class ReadModifyWriteOperation extends Operation<Object>
 {
     public static final int TYPE = 1;
+    public static final String TABLE = "table";
+    public static final String KEY = "key";
+    public static final String READ_FIELDS = "readFields";
+    public static final String WRITE_VALUES = "writeValues";
 
     private final String table;
     private final String key;
@@ -49,10 +53,10 @@ public class ReadModifyWriteOperation extends Operation<Object>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("table", table)
-                .put("key", key)
-                .put("fields", readFields)
-                .put("values", writeValues)
+                .put(TABLE, table)
+                .put(KEY, key)
+                .put(READ_FIELDS, readFields)
+                .put(WRITE_VALUES, writeValues)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/simple/ReadModifyWriteOperation.java
+++ b/src/main/java/com/ldbc/driver/workloads/simple/ReadModifyWriteOperation.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.simple;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 
 import java.util.Iterator;
@@ -43,6 +44,16 @@ public class ReadModifyWriteOperation extends Operation<Object>
     public Map<String,Iterator<Byte>> values()
     {
         return writeValues;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("table", table)
+                .put("key", key)
+                .put("fields", readFields)
+                .put("values", writeValues)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/simple/ReadOperation.java
+++ b/src/main/java/com/ldbc/driver/workloads/simple/ReadOperation.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.simple;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 
 import java.util.Iterator;
@@ -34,6 +35,15 @@ public class ReadOperation extends Operation<Map<String,Iterator<Byte>>>
     public List<String> fields()
     {
         return fields;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("table", table)
+                .put("key", key)
+                .put("fields", fields)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/simple/ReadOperation.java
+++ b/src/main/java/com/ldbc/driver/workloads/simple/ReadOperation.java
@@ -10,6 +10,9 @@ import java.util.Map;
 public class ReadOperation extends Operation<Map<String,Iterator<Byte>>>
 {
     public static final int TYPE = 3;
+    public static final String TABLE = "table";
+    public static final String KEY = "key";
+    public static final String FIELDS = "fields";
 
     private final String table;
     private final String key;
@@ -40,9 +43,9 @@ public class ReadOperation extends Operation<Map<String,Iterator<Byte>>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("table", table)
-                .put("key", key)
-                .put("fields", fields)
+                .put(TABLE, table)
+                .put(KEY, key)
+                .put(FIELDS, fields)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/simple/ScanOperation.java
+++ b/src/main/java/com/ldbc/driver/workloads/simple/ScanOperation.java
@@ -11,6 +11,10 @@ import java.util.Vector;
 public class ScanOperation extends Operation<Vector<Map<String,Iterator<Byte>>>>
 {
     public static final int TYPE = 5;
+    public static final String TABLE = "table";
+    public static final String START_KEY = "startKey";
+    public static final String RECORD_COUNT = "recordCount";
+    public static final String FIELDS = "fields";
 
     private final String table;
     private final String startKey;
@@ -49,10 +53,10 @@ public class ScanOperation extends Operation<Vector<Map<String,Iterator<Byte>>>>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("table", table)
-                .put("startKey", startKey)
-                .put("recordCount", recordCount)
-                .put("fields", fields)
+                .put(TABLE, table)
+                .put(START_KEY, startKey)
+                .put(RECORD_COUNT, recordCount)
+                .put(FIELDS, fields)
                 .build();
     }
 

--- a/src/main/java/com/ldbc/driver/workloads/simple/ScanOperation.java
+++ b/src/main/java/com/ldbc/driver/workloads/simple/ScanOperation.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.simple;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 
 import java.util.Iterator;
@@ -43,6 +44,16 @@ public class ScanOperation extends Operation<Vector<Map<String,Iterator<Byte>>>>
     public List<String> fields()
     {
         return fields;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("table", table)
+                .put("startKey", startKey)
+                .put("recordCount", recordCount)
+                .put("fields", fields)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/simple/UpdateOperation.java
+++ b/src/main/java/com/ldbc/driver/workloads/simple/UpdateOperation.java
@@ -1,5 +1,6 @@
 package com.ldbc.driver.workloads.simple;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 
 import java.util.Iterator;
@@ -32,6 +33,15 @@ public class UpdateOperation extends Operation<Object>
     public Map<String,Iterator<Byte>> fields()
     {
         return values;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put("table", table)
+                .put("key", key)
+                .put("fields", values)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/ldbc/driver/workloads/simple/UpdateOperation.java
+++ b/src/main/java/com/ldbc/driver/workloads/simple/UpdateOperation.java
@@ -9,6 +9,10 @@ import java.util.Map;
 public class UpdateOperation extends Operation<Object>
 {
     public static final int TYPE = 4;
+    public static final String TABLE = "table";
+    public static final String KEY = "key";
+    public static final String VALUES = "values";
+
     private final String table;
     private final String key;
     private final Map<String,Iterator<Byte>> values;
@@ -38,9 +42,9 @@ public class UpdateOperation extends Operation<Object>
     @Override
     public Map<String, Object> parameterMap() {
         return ImmutableMap.<String, Object>builder()
-                .put("table", table)
-                .put("key", key)
-                .put("fields", values)
+                .put(TABLE, table)
+                .put(KEY, key)
+                .put(VALUES, values)
                 .build();
     }
 

--- a/src/test/java/com/ldbc/driver/runtime/QueuePerformanceTests.java
+++ b/src/test/java/com/ldbc/driver/runtime/QueuePerformanceTests.java
@@ -1,15 +1,8 @@
 package com.ldbc.driver.runtime;
 
-import com.ldbc.driver.Operation;
-import com.ldbc.driver.SerializingMarshallingException;
-import com.ldbc.driver.Workload;
-import com.ldbc.driver.WorkloadException;
-import com.ldbc.driver.WorkloadStreams;
-import com.ldbc.driver.control.ConsoleAndFileDriverConfiguration;
-import com.ldbc.driver.control.DriverConfiguration;
-import com.ldbc.driver.control.DriverConfigurationException;
-import com.ldbc.driver.control.Log4jLoggingServiceFactory;
-import com.ldbc.driver.control.LoggingServiceFactory;
+import com.google.common.collect.ImmutableMap;
+import com.ldbc.driver.*;
+import com.ldbc.driver.control.*;
 import com.ldbc.driver.generator.GeneratorFactory;
 import com.ldbc.driver.generator.RandomDataGeneratorFactory;
 import com.ldbc.driver.temporal.SystemTimeSource;
@@ -26,13 +19,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.LinkedTransferQueue;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.is;
@@ -44,6 +31,11 @@ public class QueuePerformanceTests
 {
     final Operation TERMINATE_OPERATION = new Operation<Object>()
     {
+        @Override
+        public Map<String, Object> parameterMap() {
+            return ImmutableMap.of();
+        }
+
         @Override
         public int type()
         {

--- a/src/test/java/com/ldbc/driver/runtime/QueuePerformanceTests.java
+++ b/src/test/java/com/ldbc/driver/runtime/QueuePerformanceTests.java
@@ -32,26 +32,27 @@ public class QueuePerformanceTests
     final Operation TERMINATE_OPERATION = new Operation<Object>()
     {
         @Override
-        public Map<String, Object> parameterMap() {
-            return ImmutableMap.of();
+        public Map<String,Object> parameterMap()
+        {
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public int type()
         {
-            return -1;
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public Object marshalResult( String serializedOperationResult ) throws SerializingMarshallingException
         {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
         public String serializeResult( Object operationResultInstance ) throws SerializingMarshallingException
         {
-            return null;
+            throw new UnsupportedOperationException();
         }
     };
 

--- a/src/test/java/com/ldbc/driver/testutils/TestUtils.java
+++ b/src/test/java/com/ldbc/driver/testutils/TestUtils.java
@@ -1,23 +1,12 @@
 package com.ldbc.driver.testutils;
 
-import com.google.common.collect.Sets;
-import com.ldbc.driver.Operation;
 import com.ldbc.driver.temporal.TimeSource;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.lang.String.format;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class TestUtils
 {
@@ -65,30 +54,5 @@ public class TestUtils
                         (double) itemsGenerated /
                         testDurationAsMilli ) );
         return result;
-    }
-
-    public static <O extends Operation> void assertCorrectParameterMap(O operation) {
-        Map<String, Object> params = operation.parameterMap();
-
-        Set<Field> commonFields = Sets.newHashSet(Operation.class.getDeclaredFields());
-        Set<Field> parameter = Stream.of(operation.getClass().getDeclaredFields())
-                .filter(field -> !Modifier.isStatic(field.getModifiers()))
-                .filter(field -> !commonFields.contains(field))
-                .collect(Collectors.toSet());
-
-        parameter.forEach(field -> {
-            Object expected = null;
-            try {
-                expected = operation.getClass().getDeclaredMethod(field.getName()).invoke(operation);
-            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                e.printStackTrace();
-            }
-            Object actual = params.get(field.getName());
-
-            assertThat(
-                "Exptected parameter value " + field.getName() + " to be " + expected + ", but was " + actual,
-                actual, equalTo(expected)
-            );
-        });
     }
 }

--- a/src/test/java/com/ldbc/driver/testutils/TestUtils.java
+++ b/src/test/java/com/ldbc/driver/testutils/TestUtils.java
@@ -1,12 +1,23 @@
 package com.ldbc.driver.testutils;
 
+import com.google.common.collect.Sets;
+import com.ldbc.driver.Operation;
 import com.ldbc.driver.temporal.TimeSource;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 public class TestUtils
 {
@@ -54,5 +65,30 @@ public class TestUtils
                         (double) itemsGenerated /
                         testDurationAsMilli ) );
         return result;
+    }
+
+    public static <O extends Operation> void assertCorrectParameterMap(O operation) {
+        Map<String, Object> params = operation.parameterMap();
+
+        Set<Field> commonFields = Sets.newHashSet(Operation.class.getDeclaredFields());
+        Set<Field> parameter = Stream.of(operation.getClass().getDeclaredFields())
+                .filter(field -> !Modifier.isStatic(field.getModifiers()))
+                .filter(field -> !commonFields.contains(field))
+                .collect(Collectors.toSet());
+
+        parameter.forEach(field -> {
+            Object expected = null;
+            try {
+                expected = operation.getClass().getDeclaredMethod(field.getName()).invoke(operation);
+            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+                e.printStackTrace();
+            }
+            Object actual = params.get(field.getName());
+
+            assertThat(
+                "Exptected parameter value " + field.getName() + " to be " + expected + ", but was " + actual,
+                actual, equalTo(expected)
+            );
+        });
     }
 }

--- a/src/test/java/com/ldbc/driver/workloads/OperationMixTest.java
+++ b/src/test/java/com/ldbc/driver/workloads/OperationMixTest.java
@@ -145,38 +145,4 @@ public class OperationMixTest
         expectedInterleaves.put( 5, 50l );
         assertThat( operationMix.interleaves(), equalTo( expectedInterleaves ) );
     }
-
-    /**
-     * Make sure that all operations implement static fields for parameter names
-     */
-    @Test
-    public void parameterValidation() throws IOException {
-        List<Class> operations = ClassPath.from( ClassLoader.getSystemClassLoader() )
-                .getAllClasses().stream()
-                .filter( classInfo -> classInfo.getPackageName().startsWith( "com.ldbc.driver" ) )
-                .filter( classInfo -> !classInfo.getSimpleName().equals("") ) // ignore anonymous classes
-                .map( ClassPath.ClassInfo::load )
-                .filter( clazz -> !Modifier.isAbstract( clazz.getModifiers() ) )
-                .filter(Operation.class::isAssignableFrom)
-                .collect( toList() );
-
-        Set<Field> commonFields = Sets.newHashSet(Operation.class.getDeclaredFields());
-
-        operations.forEach(clazz -> {
-            Set<Field> allFields = Sets.newHashSet(clazz.getDeclaredFields());
-            allFields.removeAll(commonFields);
-
-            Stream<Field> nonStaticFields = allFields
-                    .stream()
-                    .filter(field -> !Modifier.isStatic(field.getModifiers()));
-
-            nonStaticFields.forEach(field -> {
-                String declaratorName = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, field.getName());
-                assertTrue(
-                        clazz.getName() + " is missing field name declaration for parameter " + field.getName(),
-                        allFields.stream().anyMatch(f -> f.getName().equals(declaratorName))
-                );
-            });
-        });
-    }
 }

--- a/src/test/java/com/ldbc/driver/workloads/OperationTest.java
+++ b/src/test/java/com/ldbc/driver/workloads/OperationTest.java
@@ -1,0 +1,99 @@
+package com.ldbc.driver.workloads;
+
+import com.google.common.base.CaseFormat;
+import com.google.common.collect.Sets;
+import com.google.common.reflect.ClassPath;
+import com.ldbc.driver.Operation;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class OperationTest
+{
+    public static <O extends Operation<?>> void assertCorrectParameterMap( O operation )
+    {
+        Map<String,Object> params = operation.parameterMap();
+
+        Set<Field> commonFields = Sets.newHashSet( Operation.class.getDeclaredFields() );
+        Set<Field> parameters = Stream.of( operation.getClass().getDeclaredFields() )
+                .filter( field -> !Modifier.isStatic( field.getModifiers() ) )
+                .filter( field -> !commonFields.contains( field ) )
+                .collect( Collectors.toSet() );
+
+        parameters.forEach( field ->
+        {
+            String fieldName = field.getName();
+            Object expected;
+            try
+            {
+                expected = operation.getClass().getDeclaredMethod( fieldName ).invoke( operation );
+            }
+            catch ( NoSuchMethodException | InvocationTargetException | IllegalAccessException e )
+            {
+                throw new RuntimeException( e );
+            }
+            Object actual = params.get( fieldName );
+
+            assertThat(
+                    "Expected " + operation.getClass().getName() + " to have parameter named '" + fieldName + "'",
+                    actual, is( notNullValue() ) );
+
+            assertThat(
+                    "Expected value of parameter '" + fieldName + "' to be " + expected + ", " + "but was " + actual,
+                    actual, equalTo( expected ) );
+        } );
+    }
+
+    /**
+     * Make sure that all operations implement static fields for parameter names
+     */
+    @Test
+    public void allOperationsShouldProvideCorrectlyNamedStaticFieldsForAccessingTheirParametersMap() throws IOException
+    {
+        List<Class> operations = ClassPath.from( ClassLoader.getSystemClassLoader() )
+                .getAllClasses().stream()
+                .filter( classInfo -> classInfo.getPackageName().startsWith( "com.ldbc.driver" ) )
+                .filter( classInfo -> !classInfo.getSimpleName().equals( "" ) ) // ignore anonymous classes
+                .map( ClassPath.ClassInfo::load )
+                .filter( clazz -> !Modifier.isAbstract( clazz.getModifiers() ) )
+                .filter( Operation.class::isAssignableFrom )
+                .collect( toList() );
+
+        Set<Field> commonFields = Sets.newHashSet( Operation.class.getDeclaredFields() );
+
+        operations.forEach( clazz ->
+        {
+            Set<Field> allFields = Sets.newHashSet( clazz.getDeclaredFields() );
+            allFields.removeAll( commonFields );
+
+            Stream<Field> nonStaticFields = allFields
+                    .stream()
+                    .filter( field -> !Modifier.isStatic( field.getModifiers() ) );
+
+            nonStaticFields.forEach( field ->
+            {
+                String expectedStaticFieldName =
+                        CaseFormat.LOWER_CAMEL.to( CaseFormat.UPPER_UNDERSCORE, field.getName() );
+                assertTrue(
+                        clazz.getName() + " is missing field name declaration for parameter " + field.getName(),
+                        allFields.stream().anyMatch( f -> f.getName().equals( expectedStaticFieldName ) )
+                );
+            } );
+        } );
+    }
+}

--- a/src/test/java/com/ldbc/driver/workloads/dummy/NothingOperation.java
+++ b/src/test/java/com/ldbc/driver/workloads/dummy/NothingOperation.java
@@ -1,9 +1,17 @@
 package com.ldbc.driver.workloads.dummy;
 
+import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
+
+import java.util.Map;
 
 public class NothingOperation extends Operation<DummyResult> {
     public static final int TYPE = 0;
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.of();
+    }
 
     @Override
     public boolean equals(Object that) {

--- a/src/test/java/com/ldbc/driver/workloads/dummy/TimedNamedOperation1.java
+++ b/src/test/java/com/ldbc/driver/workloads/dummy/TimedNamedOperation1.java
@@ -1,7 +1,13 @@
 package com.ldbc.driver.workloads.dummy;
 
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
 public class TimedNamedOperation1 extends NothingOperation {
     public static final int TYPE = 1;
+    public static final String NAME = "name";
+
     private final String name;
 
     public TimedNamedOperation1(long scheduledStartTimeAsMilli, long timeStamp, long dependencyTimeAsMilli, String name) {
@@ -13,6 +19,13 @@ public class TimedNamedOperation1 extends NothingOperation {
 
     public String name() {
         return name;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put(NAME, name)
+                .build();
     }
 
     @Override

--- a/src/test/java/com/ldbc/driver/workloads/dummy/TimedNamedOperation2.java
+++ b/src/test/java/com/ldbc/driver/workloads/dummy/TimedNamedOperation2.java
@@ -1,7 +1,12 @@
 package com.ldbc.driver.workloads.dummy;
 
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
 public class TimedNamedOperation2 extends NothingOperation {
     public static final int TYPE = 2;
+    public static final String NAME = "name";
     private final String name;
 
     public TimedNamedOperation2(long startTimeAsMilli, long timeStamp, long dependencyTimeAsMilli, String name) {
@@ -13,6 +18,13 @@ public class TimedNamedOperation2 extends NothingOperation {
 
     public String name() {
         return name;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put(NAME, name)
+                .build();
     }
 
     @Override

--- a/src/test/java/com/ldbc/driver/workloads/dummy/TimedNamedOperation3.java
+++ b/src/test/java/com/ldbc/driver/workloads/dummy/TimedNamedOperation3.java
@@ -1,7 +1,12 @@
 package com.ldbc.driver.workloads.dummy;
 
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
 public class TimedNamedOperation3 extends NothingOperation {
     public static final int TYPE = 3;
+    public static final String NAME = "name";
     private final String name;
 
     public TimedNamedOperation3(long scheduledStartTimeAsMilli, long timeStamp, long dependencyTime, String name) {
@@ -13,6 +18,13 @@ public class TimedNamedOperation3 extends NothingOperation {
 
     public String name() {
         return name;
+    }
+
+    @Override
+    public Map<String, Object> parameterMap() {
+        return ImmutableMap.<String, Object>builder()
+                .put(NAME, name)
+                .build();
     }
 
     @Override

--- a/src/test/java/com/ldbc/driver/workloads/ldbc/snb/bi/BiReadEventStreamReadersTest.java
+++ b/src/test/java/com/ldbc/driver/workloads/ldbc/snb/bi/BiReadEventStreamReadersTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Lists;
 import com.ldbc.driver.WorkloadException;
 import com.ldbc.driver.generator.GeneratorFactory;
 import com.ldbc.driver.generator.RandomDataGeneratorFactory;
+import com.ldbc.driver.testutils.TestUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
@@ -40,6 +41,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery1PostingSummary) reader.next();
         assertThat( operation.date(), is( 1441351591755l ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery1PostingSummary) reader.next();
         assertThat( operation.date(), is( 1441351591756l ) );
@@ -74,6 +76,7 @@ public class BiReadEventStreamReadersTest
         assertThat( operation.date2(), is( 1441351591755l ) );
         assertThat( operation.country1(), is( "countryA" ) );
         assertThat( operation.country2(), is( "countryB" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery2TopTags) reader.next();
         assertThat( operation.date1(), is( 1441351591755l ) );
@@ -118,6 +121,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery3TagEvolution) reader.next();
         assertThat( operation.year(), is( 1 ) );
         assertThat( operation.month(), is( 2 ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery3TagEvolution) reader.next();
         assertThat( operation.year(), is( 3 ) );
@@ -152,6 +156,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery4PopularCountryTopics) reader.next();
         assertThat( operation.tagClass(), is( "Writer" ) );
         assertThat( operation.country(), is( "Cameroon" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery4PopularCountryTopics) reader.next();
         assertThat( operation.tagClass(), is( "Writer" ) );
@@ -193,6 +198,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery5TopCountryPosters) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery5TopCountryPosters) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -230,6 +236,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery6ActivePosters) reader.next();
         assertThat( operation.tag(), is( "Justin_Timberlake" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery6ActivePosters) reader.next();
         assertThat( operation.tag(), is( "Josip_Broz_Tito" ) );
@@ -267,6 +274,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery7AuthoritativeUsers) reader.next();
         assertThat( operation.tag(), is( "Franz_Schubert" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery7AuthoritativeUsers) reader.next();
         assertThat( operation.tag(), is( "Bill_Clinton" ) );
@@ -304,6 +312,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery8RelatedTopics) reader.next();
         assertThat( operation.tag(), is( "Alanis_Morissette" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery8RelatedTopics) reader.next();
         assertThat( operation.tag(), is( "\u00c9amon_de_Valera" ) );
@@ -343,6 +352,7 @@ public class BiReadEventStreamReadersTest
         assertThat( operation.tagClass1(), is( "Person" ) );
         assertThat( operation.tagClass2(), is( "OfficeHolder" ) );
         assertThat( operation.threshold(), is( 1 ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery9RelatedForums) reader.next();
         assertThat( operation.tagClass1(), is( "Person" ) );
@@ -388,6 +398,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery10TagPerson) reader.next();
         assertThat( operation.tag(), is( "Franz_Schubert" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery10TagPerson) reader.next();
         assertThat( operation.tag(), is( "Bill_Clinton" ) );
@@ -426,6 +437,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery11UnrelatedReplies) reader.next();
         assertThat( operation.country(), is( "Cameroon" ) );
         assertThat( operation.blackList(), CoreMatchers.<List<String>>is( Lists.newArrayList( "Writer", "Reader" ) ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery11UnrelatedReplies) reader.next();
         assertThat( operation.country(), is( "Colombia" ) );
@@ -467,6 +479,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery12TrendingPosts) reader.next();
         assertThat( operation.date(), is( 1441351591755l ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery12TrendingPosts) reader.next();
         assertThat( operation.date(), is( 1441351591756l ) );
@@ -498,6 +511,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery13PopularMonthlyTags) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery13PopularMonthlyTags) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -536,6 +550,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery14TopThreadInitiators) reader.next();
         assertThat( operation.beginDate(), is( 1441351591755l ) );
         assertThat( operation.endDate(), is( 1441351591756l ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery14TopThreadInitiators) reader.next();
         assertThat( operation.beginDate(), is( 1441351591756l ) );
@@ -569,6 +584,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery15SocialNormals) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery15SocialNormals) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -608,6 +624,7 @@ public class BiReadEventStreamReadersTest
         assertThat( operation.personId(), is( 1l ) );
         assertThat( operation.country(), is( "Cameroon" ) );
         assertThat( operation.tagClass(), is( "Writer" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery16ExpertsInSocialCircle) reader.next();
         assertThat( operation.personId(), is( 2l ) );
@@ -653,6 +670,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery17FriendshipTriangles) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery17FriendshipTriangles) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -690,6 +708,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery18PersonPostCounts) reader.next();
         assertThat( operation.date(), is( 1441351591755l ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery18PersonPostCounts) reader.next();
         assertThat( operation.date(), is( 1441351591756l ) );
@@ -723,6 +742,7 @@ public class BiReadEventStreamReadersTest
         assertThat( operation.date(), is( 1l ) );
         assertThat( operation.tagClass1(), is( "Writer" ) );
         assertThat( operation.tagClass2(), is( "Single" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery19StrangerInteraction) reader.next();
         assertThat( operation.date(), is( 2l ) );
@@ -768,6 +788,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery20HighLevelTopics) reader.next();
         assertThat( operation.tagClasses(), CoreMatchers.<List<String>>is( Lists.newArrayList( "a", "b", "c" ) ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery20HighLevelTopics) reader.next();
         assertThat( operation.tagClasses(), CoreMatchers.<List<String>>is( Lists.newArrayList( "b", "c" ) ) );
@@ -804,6 +825,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery21Zombies) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
         assertThat( operation.endDate(), is( 1l ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery21Zombies) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -846,6 +868,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery22InternationalDialog) reader.next();
         assertThat( operation.country1(), is( "Germany" ) );
         assertThat( operation.country2(), is( "Pakistan" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery22InternationalDialog) reader.next();
         assertThat( operation.country1(), is( "Germany" ) );
@@ -887,6 +910,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery23HolidayDestinations) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery23HolidayDestinations) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -924,6 +948,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery24MessagesByTopic) reader.next();
         assertThat( operation.tagClass(), is( "Person" ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery24MessagesByTopic) reader.next();
         assertThat( operation.tagClass(), is( "OfficeHolder" ) );
@@ -964,6 +989,7 @@ public class BiReadEventStreamReadersTest
         assertThat( operation.person2Id(), is( 2L ) );
         assertThat( operation.startDate(), is( 1L ) );
         assertThat( operation.endDate(), is( 2L ) );
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery25WeightedPaths) reader.next();
         assertThat( operation.person1Id(), is( 3L ) );

--- a/src/test/java/com/ldbc/driver/workloads/ldbc/snb/bi/BiReadEventStreamReadersTest.java
+++ b/src/test/java/com/ldbc/driver/workloads/ldbc/snb/bi/BiReadEventStreamReadersTest.java
@@ -5,7 +5,7 @@ import com.google.common.collect.Lists;
 import com.ldbc.driver.WorkloadException;
 import com.ldbc.driver.generator.GeneratorFactory;
 import com.ldbc.driver.generator.RandomDataGeneratorFactory;
-import com.ldbc.driver.testutils.TestUtils;
+import com.ldbc.driver.workloads.OperationTest;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
@@ -41,7 +41,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery1PostingSummary) reader.next();
         assertThat( operation.date(), is( 1441351591755l ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery1PostingSummary) reader.next();
         assertThat( operation.date(), is( 1441351591756l ) );
@@ -76,7 +76,7 @@ public class BiReadEventStreamReadersTest
         assertThat( operation.date2(), is( 1441351591755l ) );
         assertThat( operation.country1(), is( "countryA" ) );
         assertThat( operation.country2(), is( "countryB" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery2TopTags) reader.next();
         assertThat( operation.date1(), is( 1441351591755l ) );
@@ -121,7 +121,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery3TagEvolution) reader.next();
         assertThat( operation.year(), is( 1 ) );
         assertThat( operation.month(), is( 2 ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery3TagEvolution) reader.next();
         assertThat( operation.year(), is( 3 ) );
@@ -156,7 +156,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery4PopularCountryTopics) reader.next();
         assertThat( operation.tagClass(), is( "Writer" ) );
         assertThat( operation.country(), is( "Cameroon" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery4PopularCountryTopics) reader.next();
         assertThat( operation.tagClass(), is( "Writer" ) );
@@ -198,7 +198,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery5TopCountryPosters) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery5TopCountryPosters) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -236,7 +236,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery6ActivePosters) reader.next();
         assertThat( operation.tag(), is( "Justin_Timberlake" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery6ActivePosters) reader.next();
         assertThat( operation.tag(), is( "Josip_Broz_Tito" ) );
@@ -274,7 +274,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery7AuthoritativeUsers) reader.next();
         assertThat( operation.tag(), is( "Franz_Schubert" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery7AuthoritativeUsers) reader.next();
         assertThat( operation.tag(), is( "Bill_Clinton" ) );
@@ -312,7 +312,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery8RelatedTopics) reader.next();
         assertThat( operation.tag(), is( "Alanis_Morissette" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery8RelatedTopics) reader.next();
         assertThat( operation.tag(), is( "\u00c9amon_de_Valera" ) );
@@ -352,7 +352,7 @@ public class BiReadEventStreamReadersTest
         assertThat( operation.tagClass1(), is( "Person" ) );
         assertThat( operation.tagClass2(), is( "OfficeHolder" ) );
         assertThat( operation.threshold(), is( 1 ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery9RelatedForums) reader.next();
         assertThat( operation.tagClass1(), is( "Person" ) );
@@ -398,7 +398,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery10TagPerson) reader.next();
         assertThat( operation.tag(), is( "Franz_Schubert" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery10TagPerson) reader.next();
         assertThat( operation.tag(), is( "Bill_Clinton" ) );
@@ -437,7 +437,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery11UnrelatedReplies) reader.next();
         assertThat( operation.country(), is( "Cameroon" ) );
         assertThat( operation.blackList(), CoreMatchers.<List<String>>is( Lists.newArrayList( "Writer", "Reader" ) ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery11UnrelatedReplies) reader.next();
         assertThat( operation.country(), is( "Colombia" ) );
@@ -479,7 +479,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery12TrendingPosts) reader.next();
         assertThat( operation.date(), is( 1441351591755l ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery12TrendingPosts) reader.next();
         assertThat( operation.date(), is( 1441351591756l ) );
@@ -511,7 +511,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery13PopularMonthlyTags) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery13PopularMonthlyTags) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -550,7 +550,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery14TopThreadInitiators) reader.next();
         assertThat( operation.beginDate(), is( 1441351591755l ) );
         assertThat( operation.endDate(), is( 1441351591756l ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery14TopThreadInitiators) reader.next();
         assertThat( operation.beginDate(), is( 1441351591756l ) );
@@ -584,7 +584,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery15SocialNormals) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery15SocialNormals) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -624,7 +624,7 @@ public class BiReadEventStreamReadersTest
         assertThat( operation.personId(), is( 1l ) );
         assertThat( operation.country(), is( "Cameroon" ) );
         assertThat( operation.tagClass(), is( "Writer" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery16ExpertsInSocialCircle) reader.next();
         assertThat( operation.personId(), is( 2l ) );
@@ -670,7 +670,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery17FriendshipTriangles) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery17FriendshipTriangles) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -708,7 +708,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery18PersonPostCounts) reader.next();
         assertThat( operation.date(), is( 1441351591755l ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery18PersonPostCounts) reader.next();
         assertThat( operation.date(), is( 1441351591756l ) );
@@ -742,7 +742,7 @@ public class BiReadEventStreamReadersTest
         assertThat( operation.date(), is( 1l ) );
         assertThat( operation.tagClass1(), is( "Writer" ) );
         assertThat( operation.tagClass2(), is( "Single" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery19StrangerInteraction) reader.next();
         assertThat( operation.date(), is( 2l ) );
@@ -788,7 +788,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery20HighLevelTopics) reader.next();
         assertThat( operation.tagClasses(), CoreMatchers.<List<String>>is( Lists.newArrayList( "a", "b", "c" ) ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery20HighLevelTopics) reader.next();
         assertThat( operation.tagClasses(), CoreMatchers.<List<String>>is( Lists.newArrayList( "b", "c" ) ) );
@@ -825,7 +825,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery21Zombies) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
         assertThat( operation.endDate(), is( 1l ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery21Zombies) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -868,7 +868,7 @@ public class BiReadEventStreamReadersTest
         operation = (LdbcSnbBiQuery22InternationalDialog) reader.next();
         assertThat( operation.country1(), is( "Germany" ) );
         assertThat( operation.country2(), is( "Pakistan" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery22InternationalDialog) reader.next();
         assertThat( operation.country1(), is( "Germany" ) );
@@ -910,7 +910,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery23HolidayDestinations) reader.next();
         assertThat( operation.country(), is( "Kenya" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery23HolidayDestinations) reader.next();
         assertThat( operation.country(), is( "Peru" ) );
@@ -948,7 +948,7 @@ public class BiReadEventStreamReadersTest
 
         operation = (LdbcSnbBiQuery24MessagesByTopic) reader.next();
         assertThat( operation.tagClass(), is( "Person" ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery24MessagesByTopic) reader.next();
         assertThat( operation.tagClass(), is( "OfficeHolder" ) );
@@ -989,7 +989,7 @@ public class BiReadEventStreamReadersTest
         assertThat( operation.person2Id(), is( 2L ) );
         assertThat( operation.startDate(), is( 1L ) );
         assertThat( operation.endDate(), is( 2L ) );
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcSnbBiQuery25WeightedPaths) reader.next();
         assertThat( operation.person1Id(), is( 3L ) );

--- a/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveReadEventStreamReadersTest.java
+++ b/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveReadEventStreamReadersTest.java
@@ -3,7 +3,7 @@ package com.ldbc.driver.workloads.ldbc.snb.interactive;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.csv.charseeker.*;
 import com.ldbc.driver.generator.CsvEventStreamReaderBasicCharSeeker;
-import com.ldbc.driver.testutils.TestUtils;
+import com.ldbc.driver.workloads.OperationTest;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -45,7 +45,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery1) reader.next();
         assertThat(operation.personId(), is(10995117334833L));
         assertThat(operation.firstName(), equalTo("John"));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery1) reader.next();
         assertThat(operation.personId(), is(14293651244033L));
@@ -95,7 +95,7 @@ public class InteractiveReadEventStreamReadersTest
         calendar.clear();
         calendar.set(2013, Calendar.JANUARY, 28);
         assertThat(operation.maxDate().getTime(), is(calendar.getTime().getTime()));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery2) reader.next();
         assertThat(operation.personId(), is(9895606011404L));
@@ -153,7 +153,7 @@ public class InteractiveReadEventStreamReadersTest
         calendar.clear();
         calendar.set(2011, Calendar.DECEMBER, 1);
         assertThat(operation.startDate().getTime(), is(calendar.getTime().getTime()));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery3) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -274,7 +274,7 @@ public class InteractiveReadEventStreamReadersTest
         calendar.clear();
         calendar.set(2012, Calendar.DECEMBER, 15);
         assertThat(operation.minDate().getTime(), is(calendar.getTime().getTime()));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery5) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -325,7 +325,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery6) reader.next();
         assertThat(operation.personId(), is(9895605643992L));
         assertThat(operation.tagName(), is("Jiang_Zemin"));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery6) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -369,7 +369,7 @@ public class InteractiveReadEventStreamReadersTest
 
         operation = (LdbcQuery7) reader.next();
         assertThat(operation.personId(), is(16492675436774L));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery7) reader.next();
         assertThat(operation.personId(), is(14293651330072L));
@@ -410,7 +410,7 @@ public class InteractiveReadEventStreamReadersTest
 
         operation = (LdbcQuery8) reader.next();
         assertThat(operation.personId(), is(15393164184077L));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery8) reader.next();
         assertThat(operation.personId(), is(15393163594341L));
@@ -456,7 +456,7 @@ public class InteractiveReadEventStreamReadersTest
         calendar.clear();
         calendar.set(2011, Calendar.DECEMBER, 22);
         assertThat(operation.maxDate().getTime(), is(calendar.getTime().getTime()));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery9) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -507,7 +507,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery10) reader.next();
         assertThat(operation.personId(), is(9895605643992L));
         assertThat(operation.month(), is(2));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery10) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -554,7 +554,7 @@ public class InteractiveReadEventStreamReadersTest
         assertThat(operation.personId(), is(9895605643992L));
         assertThat(operation.countryName(), is("Taiwan"));
         assertThat(operation.workFromYear(), is(2013));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery11) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -602,7 +602,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery12) reader.next();
         assertThat(operation.personId(), is(12094628092905L));
         assertThat(operation.tagClassName(), equalTo("SoccerManager"));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery12) reader.next();
         assertThat(operation.personId(), is(9895606011404L));
@@ -647,7 +647,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery13) reader.next();
         assertThat(operation.person1Id(), is(9895605643992L));
         assertThat(operation.person2Id(), is(1099512323797L));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery13) reader.next();
         assertThat(operation.person1Id(), is(979201L));
@@ -692,7 +692,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery14) reader.next();
         assertThat(operation.person1Id(), is(9895605643992L));
         assertThat(operation.person2Id(), is(4398046737628L));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery14) reader.next();
         assertThat(operation.person1Id(), is(979201L));

--- a/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveReadEventStreamReadersTest.java
+++ b/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveReadEventStreamReadersTest.java
@@ -3,14 +3,13 @@ package com.ldbc.driver.workloads.ldbc.snb.interactive;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.csv.charseeker.*;
 import com.ldbc.driver.generator.CsvEventStreamReaderBasicCharSeeker;
+import com.ldbc.driver.testutils.TestUtils;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.text.ParseException;
-import java.util.Calendar;
-import java.util.Iterator;
-import java.util.TimeZone;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -46,6 +45,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery1) reader.next();
         assertThat(operation.personId(), is(10995117334833L));
         assertThat(operation.firstName(), equalTo("John"));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery1) reader.next();
         assertThat(operation.personId(), is(14293651244033L));
@@ -58,6 +58,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery1) reader.next();
         assertThat(operation.personId(), is(2199023331001L));
         assertThat(operation.firstName(), equalTo("Chen"));
+
 
         assertThat(reader.hasNext(), is(false));
     }
@@ -94,6 +95,7 @@ public class InteractiveReadEventStreamReadersTest
         calendar.clear();
         calendar.set(2013, Calendar.JANUARY, 28);
         assertThat(operation.maxDate().getTime(), is(calendar.getTime().getTime()));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery2) reader.next();
         assertThat(operation.personId(), is(9895606011404L));
@@ -151,6 +153,7 @@ public class InteractiveReadEventStreamReadersTest
         calendar.clear();
         calendar.set(2011, Calendar.DECEMBER, 1);
         assertThat(operation.startDate().getTime(), is(calendar.getTime().getTime()));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery3) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -168,7 +171,6 @@ public class InteractiveReadEventStreamReadersTest
         assertThat(operation.durationDays(), is(58));
         calendar.clear();
         calendar.set(2011, Calendar.MAY, 1);
-        assertThat(operation.startDate().getTime(), is(calendar.getTime().getTime()));
 
         operation = (LdbcQuery3) reader.next();
         assertThat(operation.personId(), is(13194140498760L));
@@ -272,6 +274,7 @@ public class InteractiveReadEventStreamReadersTest
         calendar.clear();
         calendar.set(2012, Calendar.DECEMBER, 15);
         assertThat(operation.minDate().getTime(), is(calendar.getTime().getTime()));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery5) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -322,6 +325,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery6) reader.next();
         assertThat(operation.personId(), is(9895605643992L));
         assertThat(operation.tagName(), is("Jiang_Zemin"));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery6) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -365,6 +369,7 @@ public class InteractiveReadEventStreamReadersTest
 
         operation = (LdbcQuery7) reader.next();
         assertThat(operation.personId(), is(16492675436774L));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery7) reader.next();
         assertThat(operation.personId(), is(14293651330072L));
@@ -405,6 +410,7 @@ public class InteractiveReadEventStreamReadersTest
 
         operation = (LdbcQuery8) reader.next();
         assertThat(operation.personId(), is(15393164184077L));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery8) reader.next();
         assertThat(operation.personId(), is(15393163594341L));
@@ -450,6 +456,7 @@ public class InteractiveReadEventStreamReadersTest
         calendar.clear();
         calendar.set(2011, Calendar.DECEMBER, 22);
         assertThat(operation.maxDate().getTime(), is(calendar.getTime().getTime()));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery9) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -500,6 +507,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery10) reader.next();
         assertThat(operation.personId(), is(9895605643992L));
         assertThat(operation.month(), is(2));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery10) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -546,6 +554,7 @@ public class InteractiveReadEventStreamReadersTest
         assertThat(operation.personId(), is(9895605643992L));
         assertThat(operation.countryName(), is("Taiwan"));
         assertThat(operation.workFromYear(), is(2013));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery11) reader.next();
         assertThat(operation.personId(), is(979201L));
@@ -593,6 +602,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery12) reader.next();
         assertThat(operation.personId(), is(12094628092905L));
         assertThat(operation.tagClassName(), equalTo("SoccerManager"));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery12) reader.next();
         assertThat(operation.personId(), is(9895606011404L));
@@ -637,6 +647,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery13) reader.next();
         assertThat(operation.person1Id(), is(9895605643992L));
         assertThat(operation.person2Id(), is(1099512323797L));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery13) reader.next();
         assertThat(operation.person1Id(), is(979201L));
@@ -681,6 +692,7 @@ public class InteractiveReadEventStreamReadersTest
         operation = (LdbcQuery14) reader.next();
         assertThat(operation.person1Id(), is(9895605643992L));
         assertThat(operation.person2Id(), is(4398046737628L));
+        TestUtils.assertCorrectParameterMap(operation);
 
         operation = (LdbcQuery14) reader.next();
         assertThat(operation.person1Id(), is(979201L));
@@ -696,4 +708,5 @@ public class InteractiveReadEventStreamReadersTest
 
         assertThat(reader.hasNext(), is(false));
     }
+
 }

--- a/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveShortReadGeneratorTest.java
+++ b/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveShortReadGeneratorTest.java
@@ -6,7 +6,7 @@ import com.google.common.collect.Sets;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.WorkloadException;
 import com.ldbc.driver.generator.RandomDataGeneratorFactory;
-import com.ldbc.driver.testutils.TestUtils;
+import com.ldbc.driver.workloads.OperationTest;
 import com.ldbc.driver.workloads.ldbc.snb.interactive.db.DummyLdbcSnbInteractiveOperationInstances;
 import com.ldbc.driver.workloads.ldbc.snb.interactive.db.DummyLdbcSnbInteractiveOperationResultInstances;
 import org.junit.Test;
@@ -93,7 +93,7 @@ public class InteractiveShortReadGeneratorTest
         // round robbin will choose short read 1 before short read 4
         assertThat(operation.type(), equalTo(LdbcShortQuery1PersonProfile.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(2l));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
 
         assertThat(state, is(initialProbability));
@@ -111,7 +111,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery2PersonPosts.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(3l));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability));
@@ -127,7 +127,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery3PersonFriends.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(4l));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor));
@@ -143,7 +143,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery4MessageContent.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(5l));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor));
@@ -159,7 +159,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery5MessageCreator.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(6l));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor));
@@ -172,7 +172,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery6MessageForum.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(7l));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor));
@@ -185,7 +185,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery7MessageReplies.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(8l));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor - probabilityDegradationFactor));
@@ -201,7 +201,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery1PersonProfile.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(9l));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor - probabilityDegradationFactor));
@@ -217,7 +217,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery2PersonPosts.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(10l));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor - probabilityDegradationFactor));
@@ -233,7 +233,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery3PersonFriends.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(11l));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor - probabilityDegradationFactor - probabilityDegradationFactor));
@@ -249,7 +249,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery4MessageContent.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(12l));
-        TestUtils.assertCorrectParameterMap(operation);
+        OperationTest.assertCorrectParameterMap(operation);
     }
 
     @Test

--- a/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveShortReadGeneratorTest.java
+++ b/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveShortReadGeneratorTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Sets;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.WorkloadException;
 import com.ldbc.driver.generator.RandomDataGeneratorFactory;
+import com.ldbc.driver.testutils.TestUtils;
 import com.ldbc.driver.workloads.ldbc.snb.interactive.db.DummyLdbcSnbInteractiveOperationInstances;
 import com.ldbc.driver.workloads.ldbc.snb.interactive.db.DummyLdbcSnbInteractiveOperationResultInstances;
 import org.junit.Test;
@@ -92,6 +93,7 @@ public class InteractiveShortReadGeneratorTest
         // round robbin will choose short read 1 before short read 4
         assertThat(operation.type(), equalTo(LdbcShortQuery1PersonProfile.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(2l));
+        TestUtils.assertCorrectParameterMap(operation);
 
 
         assertThat(state, is(initialProbability));
@@ -109,6 +111,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery2PersonPosts.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(3l));
+        TestUtils.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability));
@@ -124,6 +127,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery3PersonFriends.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(4l));
+        TestUtils.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor));
@@ -139,6 +143,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery4MessageContent.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(5l));
+        TestUtils.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor));
@@ -154,6 +159,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery5MessageCreator.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(6l));
+        TestUtils.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor));
@@ -166,6 +172,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery6MessageForum.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(7l));
+        TestUtils.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor));
@@ -178,6 +185,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery7MessageReplies.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(8l));
+        TestUtils.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor - probabilityDegradationFactor));
@@ -193,6 +201,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery1PersonProfile.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(9l));
+        TestUtils.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor - probabilityDegradationFactor));
@@ -208,6 +217,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery2PersonPosts.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(10l));
+        TestUtils.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor - probabilityDegradationFactor));
@@ -223,6 +233,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery3PersonFriends.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(11l));
+        TestUtils.assertCorrectParameterMap(operation);
 
         state = shortReadGenerator.updateState(state, operation.type());
         assertThat(state, is(initialProbability - probabilityDegradationFactor - probabilityDegradationFactor - probabilityDegradationFactor));
@@ -238,6 +249,7 @@ public class InteractiveShortReadGeneratorTest
         );
         assertThat(operation.type(), equalTo(LdbcShortQuery4MessageContent.TYPE));
         assertThat(operation.scheduledStartTimeAsMilli(), equalTo(12l));
+        TestUtils.assertCorrectParameterMap(operation);
     }
 
     @Test

--- a/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveWriteEventStreamReaderTest.java
+++ b/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveWriteEventStreamReaderTest.java
@@ -7,7 +7,7 @@ import com.ldbc.driver.csv.charseeker.CharSeeker;
 import com.ldbc.driver.csv.charseeker.Extractors;
 import com.ldbc.driver.csv.charseeker.Readables;
 import com.ldbc.driver.csv.simple.SimpleCsvFileReader;
-import com.ldbc.driver.testutils.TestUtils;
+import com.ldbc.driver.workloads.OperationTest;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -77,7 +77,7 @@ public class InteractiveWriteEventStreamReaderTest
                 new LdbcUpdate1AddPerson.Organization(913L, 1971),
                 new LdbcUpdate1AddPerson.Organization(1539L, 1971)
         )));
-        TestUtils.assertCorrectParameterMap(addPerson);
+        OperationTest.assertCorrectParameterMap(addPerson);
 
         LdbcUpdate2AddPostLike addPostLike = (LdbcUpdate2AddPostLike) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -88,7 +88,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addPostLike.personId(), is(1582L));
         assertThat(addPostLike.postId(), is(120207L));
         assertThat(addPostLike.creationDate(), equalTo(creationDate));
-        TestUtils.assertCorrectParameterMap(addPostLike);
+        OperationTest.assertCorrectParameterMap(addPostLike);
 
         LdbcUpdate3AddCommentLike addCommentLike = (LdbcUpdate3AddCommentLike) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -99,7 +99,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addCommentLike.personId(), is(1095L));
         assertThat(addCommentLike.commentId(), is(120426L));
         assertThat(addCommentLike.creationDate(), equalTo(creationDate));
-        TestUtils.assertCorrectParameterMap(addCommentLike);
+        OperationTest.assertCorrectParameterMap(addCommentLike);
 
         LdbcUpdate4AddForum addForum = (LdbcUpdate4AddForum) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -112,7 +112,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addForum.creationDate(), equalTo(creationDate));
         assertThat(addForum.moderatorPersonId(), is(989L));
         assertThat(addForum.tagIds(), equalTo((List) Lists.newArrayList(10716l)));
-        TestUtils.assertCorrectParameterMap(addForum);
+        OperationTest.assertCorrectParameterMap(addForum);
 
         LdbcUpdate5AddForumMembership addForumMembership = (LdbcUpdate5AddForumMembership) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -123,7 +123,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addForumMembership.forumId(), is(2153L));
         assertThat(addForumMembership.personId(), is(372L));
         assertThat(addForumMembership.joinDate(), equalTo(creationDate));
-        TestUtils.assertCorrectParameterMap(addForumMembership);
+        OperationTest.assertCorrectParameterMap(addForumMembership);
 
         LdbcUpdate6AddPost addPost = (LdbcUpdate6AddPost) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -143,7 +143,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addPost.forumId(), is(2152L));
         assertThat(addPost.countryId(), is(9L));
         assertThat(addPost.tagIds(), equalTo((List) Lists.newArrayList(1437l)));
-        TestUtils.assertCorrectParameterMap(addPost);
+        OperationTest.assertCorrectParameterMap(addPost);
 
         LdbcUpdate7AddComment addComment = (LdbcUpdate7AddComment) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -162,7 +162,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addComment.replyToPostId(), is(-1L));
         assertThat(addComment.replyToCommentId(), is(4034289L));
         assertThat(addComment.tagIds(), equalTo((List) Lists.newArrayList(1403l, 1990l, 2009l, 2081l, 2817l, 2855l, 2987l, 6316l, 7425l, 8224l, 8466l)));
-        TestUtils.assertCorrectParameterMap(addComment);
+        OperationTest.assertCorrectParameterMap(addComment);
 
         addComment = (LdbcUpdate7AddComment) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -181,7 +181,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addComment.replyToPostId(), is(-1L));
         assertThat(addComment.replyToCommentId(), is(4034289L));
         assertThat(addComment.tagIds(), equalTo((List) Lists.newArrayList()));
-        TestUtils.assertCorrectParameterMap(addComment);
+        OperationTest.assertCorrectParameterMap(addComment);
 
         LdbcUpdate8AddFriendship addFriendship = (LdbcUpdate8AddFriendship) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -192,7 +192,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addFriendship.person1Id(), is(1920L));
         assertThat(addFriendship.person2Id(), is(655L));
         assertThat(addFriendship.creationDate(), equalTo(creationDate));
-        TestUtils.assertCorrectParameterMap(addFriendship);
+        OperationTest.assertCorrectParameterMap(addFriendship);
 
         assertThat(writeEventStreamReader.hasNext(), is(false));
     }

--- a/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveWriteEventStreamReaderTest.java
+++ b/src/test/java/com/ldbc/driver/workloads/ldbc/snb/interactive/InteractiveWriteEventStreamReaderTest.java
@@ -7,6 +7,7 @@ import com.ldbc.driver.csv.charseeker.CharSeeker;
 import com.ldbc.driver.csv.charseeker.Extractors;
 import com.ldbc.driver.csv.charseeker.Readables;
 import com.ldbc.driver.csv.simple.SimpleCsvFileReader;
+import com.ldbc.driver.testutils.TestUtils;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -76,6 +77,7 @@ public class InteractiveWriteEventStreamReaderTest
                 new LdbcUpdate1AddPerson.Organization(913L, 1971),
                 new LdbcUpdate1AddPerson.Organization(1539L, 1971)
         )));
+        TestUtils.assertCorrectParameterMap(addPerson);
 
         LdbcUpdate2AddPostLike addPostLike = (LdbcUpdate2AddPostLike) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -86,6 +88,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addPostLike.personId(), is(1582L));
         assertThat(addPostLike.postId(), is(120207L));
         assertThat(addPostLike.creationDate(), equalTo(creationDate));
+        TestUtils.assertCorrectParameterMap(addPostLike);
 
         LdbcUpdate3AddCommentLike addCommentLike = (LdbcUpdate3AddCommentLike) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -96,6 +99,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addCommentLike.personId(), is(1095L));
         assertThat(addCommentLike.commentId(), is(120426L));
         assertThat(addCommentLike.creationDate(), equalTo(creationDate));
+        TestUtils.assertCorrectParameterMap(addCommentLike);
 
         LdbcUpdate4AddForum addForum = (LdbcUpdate4AddForum) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -108,6 +112,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addForum.creationDate(), equalTo(creationDate));
         assertThat(addForum.moderatorPersonId(), is(989L));
         assertThat(addForum.tagIds(), equalTo((List) Lists.newArrayList(10716l)));
+        TestUtils.assertCorrectParameterMap(addForum);
 
         LdbcUpdate5AddForumMembership addForumMembership = (LdbcUpdate5AddForumMembership) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -118,6 +123,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addForumMembership.forumId(), is(2153L));
         assertThat(addForumMembership.personId(), is(372L));
         assertThat(addForumMembership.joinDate(), equalTo(creationDate));
+        TestUtils.assertCorrectParameterMap(addForumMembership);
 
         LdbcUpdate6AddPost addPost = (LdbcUpdate6AddPost) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -137,6 +143,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addPost.forumId(), is(2152L));
         assertThat(addPost.countryId(), is(9L));
         assertThat(addPost.tagIds(), equalTo((List) Lists.newArrayList(1437l)));
+        TestUtils.assertCorrectParameterMap(addPost);
 
         LdbcUpdate7AddComment addComment = (LdbcUpdate7AddComment) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -155,6 +162,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addComment.replyToPostId(), is(-1L));
         assertThat(addComment.replyToCommentId(), is(4034289L));
         assertThat(addComment.tagIds(), equalTo((List) Lists.newArrayList(1403l, 1990l, 2009l, 2081l, 2817l, 2855l, 2987l, 6316l, 7425l, 8224l, 8466l)));
+        TestUtils.assertCorrectParameterMap(addComment);
 
         addComment = (LdbcUpdate7AddComment) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -173,6 +181,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addComment.replyToPostId(), is(-1L));
         assertThat(addComment.replyToCommentId(), is(4034289L));
         assertThat(addComment.tagIds(), equalTo((List) Lists.newArrayList()));
+        TestUtils.assertCorrectParameterMap(addComment);
 
         LdbcUpdate8AddFriendship addFriendship = (LdbcUpdate8AddFriendship) writeEventStreamReader.next();
         creationDate = new Date(1234567890l);
@@ -183,6 +192,7 @@ public class InteractiveWriteEventStreamReaderTest
         assertThat(addFriendship.person1Id(), is(1920L));
         assertThat(addFriendship.person2Id(), is(655L));
         assertThat(addFriendship.creationDate(), equalTo(creationDate));
+        TestUtils.assertCorrectParameterMap(addFriendship);
 
         assertThat(writeEventStreamReader.hasNext(), is(false));
     }


### PR DESCRIPTION
This PR adds a `parameterMap` method to the `Operation` interface. 
This method returns the operations parameter as a `Map<String, Object>`.