### PR TITLE
Fix Pom and update Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.assembly.version>2.4</maven.assembly.version>
-        <jackson.api.version>1.9.13</jackson.api.version>
+        <jackson.api.version>2.6.5</jackson.api.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <commons.io.version>2.4</commons.io.version>
@@ -88,13 +88,13 @@
             <version>${log4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <version>${jackson.api.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
             <version>${jackson.api.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <finalName>${project.artifactId}-standalone</finalName>
                     <transformers>
                         <transformer
                                 implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/src/main/java/com/ldbc/driver/runtime/metrics/ContinuousMetricSnapshot.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/ContinuousMetricSnapshot.java
@@ -1,6 +1,6 @@
 package com.ldbc.driver.runtime.metrics;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/com/ldbc/driver/runtime/metrics/DiscreteMetricSnapshot.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/DiscreteMetricSnapshot.java
@@ -1,6 +1,6 @@
 package com.ldbc.driver.runtime.metrics;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 

--- a/src/main/java/com/ldbc/driver/runtime/metrics/OperationMetricsSnapshot.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/OperationMetricsSnapshot.java
@@ -1,6 +1,6 @@
 package com.ldbc.driver.runtime.metrics;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/com/ldbc/driver/runtime/metrics/WorkloadResultsSnapshot.java
+++ b/src/main/java/com/ldbc/driver/runtime/metrics/WorkloadResultsSnapshot.java
@@ -1,16 +1,15 @@
 package com.ldbc.driver.runtime.metrics;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.ldbc.driver.runtime.ConcurrentErrorReporter;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.util.DefaultPrettyPrinter;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class WorkloadResultsSnapshot

--- a/src/main/java/com/ldbc/driver/validation/DbValidationResult.java
+++ b/src/main/java/com/ldbc/driver/validation/DbValidationResult.java
@@ -1,5 +1,9 @@
 package com.ldbc.driver.validation;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.ldbc.driver.Db;
 import com.ldbc.driver.Operation;
@@ -10,9 +14,6 @@ import com.ldbc.driver.util.MapUtils;
 import com.ldbc.driver.util.Tuple;
 import com.ldbc.driver.util.Tuple2;
 import com.ldbc.driver.util.Tuple3;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
-import org.codehaus.jackson.util.DefaultPrettyPrinter;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,7 +52,7 @@ public class DbValidationResult
         this.totalOperationsPerOperationType = new HashMap<>();
         this.objectMapper = new ObjectMapper();
         this.defaultPrettyPrinter = new DefaultPrettyPrinter();
-        this.defaultPrettyPrinter.indentArraysWith( new DefaultPrettyPrinter.Lf2SpacesIndenter() );
+        this.defaultPrettyPrinter.indentArraysWith( new DefaultIndenter("  ", DefaultIndenter.SYS_LF) );
     }
 
     void reportMissingHandlerForOperation( Operation operation )

--- a/src/main/java/com/ldbc/driver/validation/ResultsLogValidationSummary.java
+++ b/src/main/java/com/ldbc/driver/validation/ResultsLogValidationSummary.java
@@ -1,8 +1,8 @@
 package com.ldbc.driver.validation;
 
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Map;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiWorkload.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/LdbcSnbBiWorkload.java
@@ -1,5 +1,7 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ldbc.driver.ChildOperationGenerator;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
@@ -9,8 +11,6 @@ import com.ldbc.driver.WorkloadStreams;
 import com.ldbc.driver.control.ConsoleAndFileDriverConfiguration;
 import com.ldbc.driver.csv.charseeker.CharSeekerParams;
 import com.ldbc.driver.generator.GeneratorFactory;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.Closeable;
 import java.io.File;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/SerializationUtil.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/bi/SerializationUtil.java
@@ -1,8 +1,8 @@
 package com.ldbc.driver.workloads.ldbc.snb.bi;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery1.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery1.java
@@ -1,11 +1,11 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery10.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery10.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery11.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery11.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery12.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery12.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery13.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery13.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery14.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery14.java
@@ -1,12 +1,12 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery2.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery2.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery3.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery3.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery4.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery4.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery5.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery5.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery6.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery6.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery7.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery7.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery8.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery8.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery9.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcQuery9.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery1PersonProfile.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery1PersonProfile.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery2PersonPosts.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery2PersonPosts.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery3PersonFriends.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery3PersonFriends.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery4MessageContent.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery4MessageContent.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery5MessageCreator.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery5MessageCreator.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery6MessageForum.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery6MessageForum.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery7MessageReplies.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcShortQuery7MessageReplies.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcSnbInteractiveWorkload.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcSnbInteractiveWorkload.java
@@ -1,5 +1,7 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -31,8 +33,6 @@ import com.ldbc.driver.util.Tuple;
 import com.ldbc.driver.util.Tuple2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Equator;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.Closeable;
 import java.io.File;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate1AddPerson.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate1AddPerson.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import com.ldbc.driver.util.ListUtils;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate2AddPostLike.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate2AddPostLike.java
@@ -1,9 +1,9 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Date;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate3AddCommentLike.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate3AddCommentLike.java
@@ -1,9 +1,9 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Date;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate4AddForum.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate4AddForum.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import com.ldbc.driver.util.ListUtils;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate5AddForumMembership.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate5AddForumMembership.java
@@ -1,9 +1,9 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Date;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate6AddPost.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate6AddPost.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import com.ldbc.driver.util.ListUtils;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate7AddComment.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate7AddComment.java
@@ -1,10 +1,10 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
 import com.ldbc.driver.util.ListUtils;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate8AddFriendship.java
+++ b/src/main/java/com/ldbc/driver/workloads/ldbc/snb/interactive/LdbcUpdate8AddFriendship.java
@@ -1,9 +1,9 @@
 package com.ldbc.driver.workloads.ldbc.snb.interactive;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.ldbc.driver.Operation;
 import com.ldbc.driver.SerializingMarshallingException;
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Date;

--- a/src/main/java/com/ldbc/driver/workloads/simple/SimpleWorkload.java
+++ b/src/main/java/com/ldbc/driver/workloads/simple/SimpleWorkload.java
@@ -1,5 +1,7 @@
 package com.ldbc.driver.workloads.simple;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
 import com.ldbc.driver.Operation;
@@ -12,8 +14,6 @@ import com.ldbc.driver.generator.MinMaxGenerator;
 import com.ldbc.driver.util.Tuple;
 import com.ldbc.driver.util.Tuple2;
 import com.ldbc.driver.util.Tuple3;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;


### PR DESCRIPTION
This PR 
- updates Jackson to Version 2.6.5 (needed for Spark 2.2 compatibility)
- makes sure that we build both a fat jar and a standalone jar
