### PR TITLE
Fix that progress of last operation missed

### DIFF
--- a/src/main/java/com/ldbc/driver/validation/DbValidator.java
+++ b/src/main/java/com/ldbc/driver/validation/DbValidator.java
@@ -33,10 +33,26 @@ public class DbValidator
         int validationParamsCrashedSoFar = 0;
         int validationParamsIncorrectSoFar = 0;
 
-        while ( validationParameters.hasNext() )
+        Operation operation = null;
+        while ( true )
         {
+            if (null != operation) {
+                System.out.print(format(
+                        "Processed %s / %s -- Crashed %s -- Incorrect %s -- Currently processing %s...\r",
+                        numberFormat.format(validationParamsProcessedSoFar),
+                        numberFormat.format(validationParamsCount),
+                        numberFormat.format(validationParamsCrashedSoFar),
+                        numberFormat.format(validationParamsIncorrectSoFar),
+                        operation.getClass().getSimpleName()
+                ));
+            }
+
+            if (!validationParameters.hasNext()) {
+                break;
+            }
+
             ValidationParam validationParam = validationParameters.next();
-            Operation operation = validationParam.operation();
+            operation = validationParam.operation();
             Object expectedOperationResult = validationParam.operationResult();
 
             OperationHandlerRunnableContext handlerRunner;
@@ -55,14 +71,6 @@ public class DbValidator
             {
                 OperationHandler handler = handlerRunner.operationHandler();
                 DbConnectionState dbConnectionState = handlerRunner.dbConnectionState();
-                System.out.print( format(
-                        "Processed %s / %s -- Crashed %s -- Incorrect %s -- Currently processing %s...\r",
-                        numberFormat.format( validationParamsProcessedSoFar ),
-                        numberFormat.format( validationParamsCount ),
-                        numberFormat.format( validationParamsCrashedSoFar ),
-                        numberFormat.format( validationParamsIncorrectSoFar ),
-                        operation.getClass().getSimpleName()
-                ) );
                 handler.executeOperation( operation, dbConnectionState, resultReporter );
                 if ( null == resultReporter.result() )
                 {
@@ -97,7 +105,7 @@ public class DbValidator
 
             dbValidationResult.reportSuccessfulExecution( operation );
         }
-        System.out.println( "----" );
+        System.out.println( "\n----" );
         return dbValidationResult;
     }
 }


### PR DESCRIPTION
After validation, the displayed message looks like:
```
----essed 3 / 4 -- Crashed 0 -- Incorrect 3 -- Currently processing LdbcQuery14...
```
Miss the progress of last operation.